### PR TITLE
zcs-637 pick correct zmzimbratozimbramig.jar from files.zimbra.com

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -37,7 +37,7 @@
     <ivy:install organisation="zimbra" module="zm-client" revision="latest.integration" settingsRef="dev.settings" from="chain-resolver" to="build-dist" overwrite="true" transitive="true" type="jar" />
     <ivy:install organisation="zimbra" module="zm-store" revision="latest.integration" settingsRef="dev.settings" from="chain-resolver" to="build-dist" overwrite="true" transitive="true" type="jar" />
     <ivy:install organisation="log4j" module="log4j" revision="1.2.16" settingsRef="dev.settings" from="chain-resolver" to="build-dist" overwrite="true" transitive="true" type="jar" />
-
+    <ivy:install organisation="zimbra"  module="zmzimbratozimbramig" revision="8.7" settingsRef="dev.settings" from="chain-resolver" to="build-dist" overwrite="true" transitive="true" type="jar" />
     <delete>
       <fileset dir="${dist.dir}" excludes="*.jar" />
     </delete>


### PR DESCRIPTION
pick correct zmzimbratozimbramig.jar from files.zimbra.com instead of zm-migration-tools git repository. Will create task to build from source code.