### PR TITLE
Additional dependencies from the Jackson Project added to fix Bugzill…

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -65,7 +65,9 @@
   <!--  <dependency org="ical4j" name="ical4j" rev="0.9.16-patched" /> -->
   
   <dependency org="com.ibm.icu" name="icu4j" rev="4.8.1.1" />
+  <dependency org="org.codehaus.jackson" name="jackson-core-asl" rev="1.9.13"/>
   <dependency org="org.codehaus.jackson" name="jackson-mapper-asl" rev="1.9.13"/>
+  <dependency org="org.codehaus.jackson" name="jackson-xc" rev="1.9.13"/>
   <dependency org="com.github.stephenc" name="jamm" rev="0.2.5" />
   <dependency org="javax.mail" name="mail" rev="1.4.5" />
   <dependency org="javax.ws.rs" name="javax.ws.rs-api" rev="2.0-m10" />


### PR DESCRIPTION
…a Bug #107922

Added jackson-core-asl and jackson-xc version 1.9.13 from the Jackson
Project to the dependency list in order to fix Bugzilla Bug #107922,
        restoring JSON output for the zmsoap command.

See [the bugzilla bug](https://bugzilla.zimbra.com/show_bug.cgi?id=107922)
A related pull request for the zm-build repository will be created shortly to add the jar files to the zimbra-core package.