### PR TITLE
ZCS-2891 Adding jackson libs to lib/jars

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -67,6 +67,9 @@
   
   <dependency org="com.ibm.icu" name="icu4j" rev="4.8.1.1" />
   <dependency org="org.codehaus.jackson" name="jackson-mapper-asl" rev="1.9.13"/>
+  <dependency org="org.codehaus.jackson" name="jackson-core-asl" rev="1.9.13"/>
+  <dependency org="org.codehaus.jackson" name="jackson-xc" rev="1.9.13"/>
+  <dependency org="org.codehaus.jackson" name="jackson-smile" rev="1.9.13"/>
   <dependency org="com.github.stephenc" name="jamm" rev="0.2.5" />
   <dependency org="javax.mail" name="mail" rev="1.4.5" />
   <dependency org="javax.ws.rs" name="javax.ws.rs-api" rev="2.0-m10" />


### PR DESCRIPTION
Adding missing jars to /opt/zimbra/lib/jars
jackson-core-asl-1.9.13.jar, 
jackson-xc-1.9.13.jar and 
jackson-smile-1.9.13.jar