### PR TITLE
ZCS-4346, ZCS-4315 Remove zkclient dependency

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -7,7 +7,6 @@
     <dependency org="ant-contrib" name="ant-contrib" rev="1.0b2"/>
     <dependency org="asm" name="asm" rev="3.3.1"/>
     <dependency org="ch.ethz.ganymed" name="ganymed-ssh2" rev="build210"/>
-    <dependency org="com.101tec" name="zkclient" rev="0.1.0"/>
     <dependency org="com.github.stephenc" name="jamm" rev="0.2.5"/>
     <dependency org="com.google.guava" name="guava" rev="13.0.1"/>
     <dependency org="com.googlecode.concurrentlinkedhashmap" name="concurrentlinkedhashmap-lru" rev="1.3.1"/>


### PR DESCRIPTION
This library is not actually used and its presence is
creating a conflict with the ZooKeeper library we are using.