### PR TITLE
ZCS-4355 renaming 2 jars in lib/jars

### DIFF
--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -211,8 +211,8 @@ sub stage_zimbra_core_lib($)
         cpy_file("build/dist/ehcache-3.1.2.jar",                                    "$stage_base_dir/opt/zimbra/lib/jars/ehcache-3.1.2.jar");
         cpy_file("build/dist/zimbra-charset.jar",                                   "$stage_base_dir/opt/zimbra/lib/jars/zimbra-charset.jar");
         cpy_file("build/dist/ant-1.6.5.jar",                                        "$stage_base_dir/opt/zimbra/lib/jars/ant-1.6.5.jar");
-        cpy_file("build/dist/json-20090211.jar",                                    "$stage_base_dir/opt/zimbra/lib/jars/json-20090211.jar");
-        cpy_file("build/dist/commons-logging-1.1.1.jar",                            "$stage_base_dir/opt/zimbra/lib/jars/commons-logging-1.1.1.jar");
+        cpy_file("build/dist/json-20090211.jar",                                    "$stage_base_dir/opt/zimbra/lib/jars/json.jar");
+        cpy_file("build/dist/commons-logging-1.1.1.jar",                            "$stage_base_dir/opt/zimbra/lib/jars/commons-logging.jar");
 
    
    return ["."];


### PR DESCRIPTION
Renaming the following in /opt/zimbra/lib/jars

/opt/zimbra/lib/jars/commons-logging-1.1.1.jar  In 8.8.7 to   /opt/zimbra/lib/jars/commons-logging.jar
/opt/zimbra/lib/jars/json-20090211.jar while in 8.8.7  to /opt/zimbra/lib/jars/json.jar