### PR TITLE
ZCS-4723 Updating zm-zcs-lib with new version of guava

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -143,5 +143,7 @@
     <exclude org="net.sf.josql" module="gentlyweb-utils"/>
     <exclude org="net.sf.josql" module="josql"/>
     <exclude org="org.restlet" module="org.restlet"/>
+    <dependency org="com.google.javascript" name="closure-compiler" rev="v20180204"/>
+    <dependency org="com.github.zafarkhaja" name="java-semver" rev="0.9.0"/>
   </dependencies>
 </ivy-module>

--- a/ivy.xml
+++ b/ivy.xml
@@ -134,6 +134,8 @@
     <dependency org="wsdl4j" name="wsdl4j" rev="1.6.3"/>
     <dependency org="xerces" name="xercesImpl" rev="2.9.1-patch-01"/>
     <dependency org="zimbra" name="zm-ews-stub" rev="2.0"/>
+    <dependency org="com.google.javascript" name="closure-compiler" rev="v20180204"/>
+    <dependency org="com.github.zafarkhaja" name="java-semver" rev="0.9.0"/>
     <exclude org="com.noelios.restlet" module="com.noelios.restlet"/>
     <exclude org="javax.sql" module="jdbc-stdext"/>
     <exclude org="javax.transaction" module="jta"/>
@@ -143,7 +145,5 @@
     <exclude org="net.sf.josql" module="gentlyweb-utils"/>
     <exclude org="net.sf.josql" module="josql"/>
     <exclude org="org.restlet" module="org.restlet"/>
-    <dependency org="com.google.javascript" name="closure-compiler" rev="v20180204"/>
-    <dependency org="com.github.zafarkhaja" name="java-semver" rev="0.9.0"/>
   </dependencies>
 </ivy-module>

--- a/ivy.xml
+++ b/ivy.xml
@@ -9,7 +9,7 @@
     <dependency org="ch.ethz.ganymed" name="ganymed-ssh2" rev="build210"/>
     <dependency org="com.101tec" name="zkclient" rev="0.1.0"/>
     <dependency org="com.github.stephenc" name="jamm" rev="0.2.5"/>
-    <dependency org="com.google.guava" name="guava" rev="13.0.1"/>
+    <dependency org="com.google.guava" name="guava" rev="23.0"/>
     <dependency org="com.googlecode.concurrentlinkedhashmap" name="concurrentlinkedhashmap-lru" rev="1.3.1"/>
     <dependency org="com.googlecode.owasp-java-html-sanitizer" name="owasp-java-html-sanitizer" rev="r239"/>
     <dependency org="com.ibm.icu" name="icu4j" rev="4.8.1.1"/>

--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -122,7 +122,7 @@ sub stage_zimbra_core_lib($)
         cpy_file("build/dist/ganymed-ssh2-build210.jar",                            "$stage_base_dir/opt/zimbra/lib/jars/ganymed-ssh2-build210.jar");
         cpy_file("build/dist/gifencoder-0.9.jar",                                   "$stage_base_dir/opt/zimbra/lib/jars/gifencoder-0.9.jar");
         cpy_file("build/dist/gmbal-api-only-2.2.6.jar",                             "$stage_base_dir/opt/zimbra/lib/jars/gmbal-api-only-2.2.6.jar");
-        cpy_file("build/dist/guava-13.0.1.jar",                                     "$stage_base_dir/opt/zimbra/lib/jars/guava-13.0.1.jar");
+        cpy_file("build/dist/guava-23.0.jar",                                       "$stage_base_dir/opt/zimbra/lib/jars/guava-23.0.jar");
         cpy_file("build/dist/helix-core-0.6.1-incubating.jar",                      "$stage_base_dir/opt/zimbra/lib/jars/helix-core-0.6.1-incubating.jar");
         cpy_file("build/dist/httpasyncclient-4.1.2.jar",                            "$stage_base_dir/opt/zimbra/lib/jars/httpasyncclient-4.1.2.jar");
         cpy_file("build/dist/httpclient-4.5.2.jar",                                 "$stage_base_dir/opt/zimbra/lib/jars/httpclient-4.5.2.jar");
@@ -246,7 +246,7 @@ sub stage_zimbra_store_lib($)
        cpy_file("build/dist/concurrentlinkedhashmap-lru-1.3.1.jar",                 "$stage_base_dir/opt/zimbra/jetty_base/common/lib/concurrentlinkedhashmap-lru-1.3.1.jar");
        cpy_file("build/dist/dom4j-1.5.2.jar",                                       "$stage_base_dir/opt/zimbra/jetty_base/common/lib/dom4j-1.5.2.jar");
        cpy_file("build/dist/ganymed-ssh2-build210.jar",                             "$stage_base_dir/opt/zimbra/jetty_base/common/lib/ganymed-ssh2-build210.jar");
-       cpy_file("build/dist/guava-13.0.1.jar",                                      "$stage_base_dir/opt/zimbra/jetty_base/common/lib/guava-13.0.1.jar");
+       cpy_file("build/dist/guava-23.0.jar",                                        "$stage_base_dir/opt/zimbra/jetty_base/common/lib/guava-23.0.jar");
        cpy_file("build/dist/httpasyncclient-4.1.2.jar",                             "$stage_base_dir/opt/zimbra/jetty_base/common/lib/httpasyncclient-4.1.2.jar");
        cpy_file("build/dist/httpclient-4.5.2.jar",                                  "$stage_base_dir/opt/zimbra/jetty_base/common/lib/httpclient-4.5.2.jar");
        cpy_file("build/dist/httpcore-4.4.5.jar",                                    "$stage_base_dir/opt/zimbra/jetty_base/common/lib/httpcore-4.4.5.jar");

--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -278,6 +278,8 @@ sub stage_zimbra_store_lib($)
        cpy_file("build/dist/nekohtml-1.9.13.1z.jar",                                "$stage_base_dir/opt/zimbra/jetty_base/common/lib/nekohtml-1.9.13.1z.jar");
        cpy_file("build/dist/zmzimbratozimbramig-8.7.jar",                           "$stage_base_dir/opt/zimbra/lib/jars/zmzimbratozimbramig.jar");
        cpy_file("build/dist/jcharset-2.0.jar",                                      "$stage_base_dir/opt/zimbra/jetty_base/common/endorsed/jcharset.jar");
+       cpy_file("build/dist/java-semver-0.9.0.jar",                                 "$stage_base_dir/opt/zimbra/jetty_base/common/lib/java-semver-0.9.0.jar");
+       cpy_file("build/dist/closure-compiler-v2018020.jar",                         "$stage_base_dir/opt/zimbra/jetty_base/common/lib/closure-compiler-v2018020.jar");
        return ["."];
 }
 

--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -279,7 +279,7 @@ sub stage_zimbra_store_lib($)
        cpy_file("build/dist/zmzimbratozimbramig-8.7.jar",                           "$stage_base_dir/opt/zimbra/lib/jars/zmzimbratozimbramig.jar");
        cpy_file("build/dist/jcharset-2.0.jar",                                      "$stage_base_dir/opt/zimbra/jetty_base/common/endorsed/jcharset.jar");
        cpy_file("build/dist/java-semver-0.9.0.jar",                                 "$stage_base_dir/opt/zimbra/jetty_base/common/lib/java-semver-0.9.0.jar");
-       cpy_file("build/dist/closure-compiler-v2018020.jar",                         "$stage_base_dir/opt/zimbra/jetty_base/common/lib/closure-compiler-v2018020.jar");
+       cpy_file("build/dist/closure-compiler-v20180204.jar",                         "$stage_base_dir/opt/zimbra/jetty_base/common/lib/closure-compiler-v20180204.jar");
        return ["."];
 }
 


### PR DESCRIPTION
upgrade guava jar to version 23.0
Upgrade the store and core pkgs to use the new version of guava jar.