### PR TITLE
ZCS-4860 zmsoap broken for json requests

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -66,6 +66,9 @@
   
   <dependency org="com.ibm.icu" name="icu4j" rev="4.8.1.1" />
   <dependency org="org.codehaus.jackson" name="jackson-mapper-asl" rev="1.9.13"/>
+  <dependency org="org.codehaus.jackson" name="jackson-core-asl" rev="1.9.13"/>
+  <dependency org="org.codehaus.jackson" name="jackson-xc" rev="1.9.13"/>
+  <dependency org="org.codehaus.jackson" name="jackson-smile" rev="1.9.13"/>
   <dependency org="com.github.stephenc" name="jamm" rev="0.2.5" />
   <dependency org="javax.mail" name="mail" rev="1.4.5" />
   <dependency org="javax.ws.rs" name="javax.ws.rs-api" rev="2.0-m10" />


### PR DESCRIPTION
ZCS-4860 zmsoap broken for json requests
Backport for 8.7.11 p3
Including the missing jars in /opt/zimbra/lib/jars