### PR TITLE
ZCS-5214: fix build issues

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -90,7 +90,6 @@
     <dependency org="org.apache.zookeeper" name="zookeeper" rev="3.4.5"/>
     <dependency org="org.bouncycastle" name="bcmail-jdk15on" rev="1.55"/>
     <dependency org="org.bouncycastle" name="bcpkix-jdk15on" rev="1.55"/>
-    <dependency org="org.bouncycastle" name="bcprov-jdk15" rev="1.46"/>
     <dependency org="org.bouncycastle" name="bcprov-jdk15on" rev="1.55"/>
     <dependency org="com.fasterxml.jackson.core" name="jackson-core" rev="2.9.2"/>
     <dependency org="com.fasterxml.jackson.core" name="jackson-annotations" rev="2.9.2"/>

--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -97,7 +97,7 @@ sub stage_zimbra_core_lib($)
         cpy_file("build/dist/apache-jsieve-core-0.5.jar",                           "$stage_base_dir/opt/zimbra/lib/jars/apache-jsieve-core-0.5.jar");
         cpy_file("build/dist/apache-log4j-extras-1.0.jar",                          "$stage_base_dir/opt/zimbra/lib/jars/apache-log4j-extras-1.0.jar");
         cpy_file("build/dist/asm-3.3.1.jar",                                        "$stage_base_dir/opt/zimbra/lib/jars/asm-3.3.1.jar");
-        cpy_file("build/dist/bcprov-jdk15-1.46.jar",                                "$stage_base_dir/opt/zimbra/lib/jars/bcprov-jdk15-1.46.jar");
+        cpy_file("build/dist/bcprov-jdk15on-1.55.jar",                              "$stage_base_dir/opt/zimbra/lib/jars/bcprov-jdk15on-1.55.jar");
         cpy_file("build/dist/commons-cli-1.2.jar",                                  "$stage_base_dir/opt/zimbra/lib/jars/commons-cli-1.2.jar");
         cpy_file("build/dist/commons-codec-1.7.jar",                                "$stage_base_dir/opt/zimbra/lib/jars/commons-codec-1.7.jar");
         cpy_file("build/dist/commons-collections-3.2.2.jar",                        "$stage_base_dir/opt/zimbra/lib/jars/commons-collections-3.2.2.jar");
@@ -224,9 +224,8 @@ sub stage_zimbra_store_lib($)
 {
    my $stage_base_dir = shift;
 
-       cpy_file("build/dist/bcpkix-jdk15on-1.55.jar",                               "$stage_base_dir/opt/zimbra/lib/ext-common/bcpkix-jdk15on-1.55.jar");
+       cpy_file("build/dist/bcpkix-jdk15on-1.55.jar",                               "$stage_base_dir/opt/zimbra/jetty_base/common/lib/bcpkix-jdk15on-1.55.jar");
        cpy_file("build/dist/bcmail-jdk15on-1.55.jar",                               "$stage_base_dir/opt/zimbra/lib/ext-common/bcmail-jdk15on-1.55.jar");
-       cpy_file("build/dist/bcprov-jdk15on-1.55.jar",                               "$stage_base_dir/opt/zimbra/lib/ext-common/bcprov-jdk15on-1.55.jar");
        cpy_file("build/dist/zmzimbratozimbramig-8.7.jar",                           "$stage_base_dir/opt/zimbra/lib/jars/zmzimbratozimbramig.jar");
        cpy_file("build/dist/jcharset-2.0.jar",                                      "$stage_base_dir/opt/zimbra/jetty_base/common/endorsed/jcharset.jar");
        cpy_file("build/dist/zimbra-charset.jar",                                    "$stage_base_dir/opt/zimbra/jetty_base/common/endorsed/zimbra-charset.jar");


### PR DESCRIPTION
1. removed old version of bcprov-jdk15 jar 
2. moved bcpkix-jdk15on-1.55 from ext-common to jetty/common/lib as it's required for store code as well as smime extension.
3. removed bcprov-jdk15on-1.55.jar from ext-common as it's already there in jetty/common/lib