### PR TITLE
ZCS-6714 Adding lib reqd. for JDK11 runtime

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>zm-zcs-lib_11</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/ivy.xml
+++ b/ivy.xml
@@ -143,6 +143,12 @@
     <dependency org="org.apache.commons" name="commons-rng-core" rev="1.0"/>
     <dependency org="org.apache.commons" name="commons-rng-simple" rev="1.0"/>
     <dependency org="com.auth0" name="java-jwt" rev="3.2.0"/>
+    <dependency org="javax.activation" name="activation" rev="1.1"/>
+    <dependency org="javax.xml.soap" name="javax.xml.soap-api" rev="1.4.0"/>
+    <dependency org="com.sun.xml.bind" name="jaxb-core" rev="2.3.0.1"/>
+    <dependency org="com.sun.xml.bind" name="jaxb-impl" rev="2.3.1"/>
+    <dependency org="javax.xml.bind" name="jaxb-api" rev="2.3.1"/>
+    <dependency org="javax.xml.ws" name="jaxws-api" rev="2.3.1"/>
     <exclude org="com.noelios.restlet" module="com.noelios.restlet"/>
     <exclude org="javax.sql" module="jdbc-stdext"/>
     <exclude org="javax.transaction" module="jta"/>

--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -227,6 +227,7 @@ sub stage_zimbra_core_lib($)
         cpy_file("build/dist/ant-1.6.5.jar",                                        "$stage_base_dir/opt/zimbra/lib/jars/ant-1.6.5.jar");
         cpy_file("build/dist/json-20090211.jar",                                    "$stage_base_dir/opt/zimbra/lib/jars/json.jar");
         cpy_file("build/dist/commons-logging-1.1.1.jar",                            "$stage_base_dir/opt/zimbra/lib/jars/commons-logging.jar");
+        cpy_file("build/dist/activation-1.1.jar",                                   "$stage_base_dir/opt/zimbra/lib/jars/activation-1.1.jar");
 
    
    return ["."];
@@ -292,12 +293,18 @@ sub stage_zimbra_store_lib($)
        cpy_file("build/dist/zmzimbratozimbramig-8.7.jar",                           "$stage_base_dir/opt/zimbra/lib/jars/zmzimbratozimbramig.jar");
        cpy_file("build/dist/jcharset-2.0.jar",                                      "$stage_base_dir/opt/zimbra/jetty_base/common/endorsed/jcharset.jar");
        cpy_file("build/dist/java-semver-0.9.0.jar",                                 "$stage_base_dir/opt/zimbra/jetty_base/common/lib/java-semver-0.9.0.jar");
-       cpy_file("build/dist/closure-compiler-v20180204.jar",                         "$stage_base_dir/opt/zimbra/jetty_base/common/lib/closure-compiler-v20180204.jar");
+       cpy_file("build/dist/closure-compiler-v20180204.jar",                        "$stage_base_dir/opt/zimbra/jetty_base/common/lib/closure-compiler-v20180204.jar");
        cpy_file("build/dist/commons-text-1.1.jar",                                  "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-text-1.1.jar");
        cpy_file("build/dist/commons-lang3-3.7.jar",                                 "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-lang3-3.7.jar");
        cpy_file("build/dist/commons-rng-client-api-1.0.jar",                        "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-rng-client-api-1.0.jar");
        cpy_file("build/dist/commons-rng-core-1.0.jar",                              "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-rng-core-1.0.jar");
        cpy_file("build/dist/commons-rng-simple-1.0.jar",                            "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-rng-simple-1.0.jar");
+       cpy_file("build/dist/activation-1.1.jar",                                    "$stage_base_dir/opt/zimbra/jetty_base/common/lib/activation-1.1.jar");
+       cpy_file("build/dist/javax.xml.soap-api-1.4.0.jar",                          "$stage_base_dir/opt/zimbra/jetty_base/common/lib/javax.xml.soap-api-1.4.0.jar");
+       cpy_file("build/dist/jaxb-core-2.3.0.1.jar",                                 "$stage_base_dir/opt/zimbra/jetty_base/common/lib/jaxb-core-2.3.0.1.jar");
+       cpy_file("build/dist/jaxb-impl-2.3.1.jar",                                   "$stage_base_dir/opt/zimbra/jetty_base/common/lib/jaxb-impl-2.3.1.jar");
+       cpy_file("build/dist/jaxb-api-2.3.1.jar",                                    "$stage_base_dir/opt/zimbra/jetty_base/common/lib/jaxb-api-2.3.1.jar");
+       cpy_file("build/dist/jaxws-api-2.3.1.jar",                                   "$stage_base_dir/opt/zimbra/jetty_base/common/lib/jaxws-api-2.3.1.jar");
        return ["."];
 }
 


### PR DESCRIPTION
Adding libraries required by ZCS which are no longer part of JDK 11.

Verified after adding these libraries  zmmailboxdctl restart is successful and ZCS web clieent and admin console function normally