### PR TITLE
zcs-6542:upgrade jetty to 9.4.18.xxx

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -95,18 +95,18 @@
     <dependency org="com.fasterxml.jackson.module" name="jackson-module-jaxb-annotations" rev="2.8.9"/>
     <dependency org="org.codehaus.woodstox" name="stax2-api" rev="3.1.1"/>
     <dependency org="org.codehaus.woodstox" name="woodstox-core-asl" rev="4.2.0"/>
-    <dependency org="org.eclipse.jetty" name="jetty-continuation" rev="9.4.15.v20190215"/>
-    <dependency org="org.eclipse.jetty" name="jetty-http" rev="9.4.15.v20190215"/>
-    <dependency org="org.eclipse.jetty" name="jetty-io" rev="9.4.15.v20190215"/>
-    <dependency org="org.eclipse.jetty" name="jetty-rewrite" rev="9.4.15.v20190215"/>
-    <dependency org="org.eclipse.jetty" name="jetty-security" rev="9.4.15.v20190215"/>
-    <dependency org="org.eclipse.jetty" name="jetty-server" rev="9.4.15.v20190215"/>
-    <dependency org="org.eclipse.jetty" name="jetty-servlet" rev="9.4.15.v20190215"/>
-    <dependency org="org.eclipse.jetty" name="jetty-servlets" rev="9.4.15.v20190215"/>
-    <dependency org="org.eclipse.jetty" name="jetty-util" rev="9.4.15.v20190215"/>
-    <dependency org="org.eclipse.jetty" name="apache-jsp" rev="9.4.15.v20190215"/>
-    <dependency org="org.eclipse.jetty" name="jetty-servlets" rev="9.4.15.v20190215"/>
-    <dependency org="org.eclipse.jetty" name="jetty-servlet" rev="9.4.15.v20190215"/>
+    <dependency org="org.eclipse.jetty" name="jetty-continuation" rev="9.4.18.v20190429"/>
+    <dependency org="org.eclipse.jetty" name="jetty-http" rev="9.4.18.v20190429"/>
+    <dependency org="org.eclipse.jetty" name="jetty-io" rev="9.4.18.v20190429"/>
+    <dependency org="org.eclipse.jetty" name="jetty-rewrite" rev="9.4.18.v20190429"/>
+    <dependency org="org.eclipse.jetty" name="jetty-security" rev="9.4.18.v20190429"/>
+    <dependency org="org.eclipse.jetty" name="jetty-server" rev="9.4.18.v20190429"/>
+    <dependency org="org.eclipse.jetty" name="jetty-servlet" rev="9.4.18.v20190429"/>
+    <dependency org="org.eclipse.jetty" name="jetty-servlets" rev="9.4.18.v20190429"/>
+    <dependency org="org.eclipse.jetty" name="jetty-util" rev="9.4.18.v20190429"/>
+    <dependency org="org.eclipse.jetty" name="apache-jsp" rev="9.4.18.v20190429"/>
+    <dependency org="org.eclipse.jetty" name="jetty-servlets" rev="9.4.18.v20190429"/>
+    <dependency org="org.eclipse.jetty" name="jetty-servlet" rev="9.4.18.v20190429"/>
     <dependency org="org.ehcache" name="ehcache" rev="3.1.2"/>
     <dependency org="org.freemarker" name="freemarker" rev="2.3.19"/>
     <dependency org="org.glassfish.gmbal" name="gmbal-api-only" rev="2.2.6"/>

--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -231,7 +231,7 @@ sub stage_zimbra_core_lib($)
         cpy_file("build/dist/istack-commons-runtime-3.0.8.jar",                     "$stage_base_dir/opt/zimbra/lib/jars/istack-commons-runtime-3.0.8.jar");
         cpy_file("build/dist/resolver-20050927.jar",                                "$stage_base_dir/opt/zimbra/lib/jars/resolver-20050927.jar");
         cpy_file("build/dist/javax.annotation-api-1.2.jar",                         "$stage_base_dir/opt/zimbra/lib/jars/javax.annotation-api-1.2.jar");
-        cpy_file("build/dist/apache-jsp-9.4.15.v20190215.jar",                      "$stage_base_dir/opt/zimbra/lib/jars/apache-jsp-9.4.15.v20190215.jar");
+        cpy_file("build/dist/apache-jsp-9.4.18.v20190429.jar",                      "$stage_base_dir/opt/zimbra/lib/jars/apache-jsp-9.4.18.v20190429.jar");
         return ["."];
 }
 
@@ -308,8 +308,8 @@ sub stage_zimbra_store_lib($)
        cpy_file("build/dist/jaxb-api-2.3.1.jar",                                    "$stage_base_dir/opt/zimbra/jetty_base/common/lib/jaxb-api-2.3.1.jar");
        cpy_file("build/dist/jaxws-api-2.3.1.jar",                                   "$stage_base_dir/opt/zimbra/jetty_base/common/lib/jaxws-api-2.3.1.jar");
        cpy_file("build/dist/saaj-impl-1.5.1.jar",                                   "$stage_base_dir/opt/zimbra/lib/ext-common/saaj-impl-1.5.1.jar");
-       cpy_file("build/dist/jetty-servlets-9.4.15.v20190215.jar",                   "$stage_base_dir/opt/zimbra/jetty/webapps/service/WEB-INF/lib/jetty-servlets-9.4.15.v20190215.jar");
-       cpy_file("build/dist/jetty-servlet-9.4.15.v20190215.jar",                    "$stage_base_dir/opt/zimbra/jetty/webapps/service/WEB-INF/lib/jetty-servlet-9.4.15.v20190215.jar");
+       cpy_file("build/dist/jetty-servlets-9.4.18.v20190429.jar",                   "$stage_base_dir/opt/zimbra/jetty/webapps/service/WEB-INF/lib/jetty-servlets-9.4.18.v20190429.jar");
+       cpy_file("build/dist/jetty-servlet-9.4.18.v20190429.jar",                    "$stage_base_dir/opt/zimbra/jetty/webapps/service/WEB-INF/lib/jetty-servlet-9.4.18.v20190429.jar");
        return ["."];
 }
 


### PR DESCRIPTION
issue : upgrade jetty to 9.4.14 or higher.

fix : previously upgraded to 9.4.15.xxx which worked fine without any issue. As 9.4.18.xxx is the latest jetty version, its better to use it. so the changes has been done according to it.  It is working fine as expected with the latest version of jetty.

Testing:
QA needs to verify it.

Related PR
https://github.com/Zimbra/zm-mailbox/pull/908