### PR TITLE
ZCS-7320 Fixed issue faced while installing build 

### DIFF
--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -308,8 +308,6 @@ sub stage_zimbra_store_lib($)
        cpy_file("build/dist/jaxb-api-2.3.1.jar",                                    "$stage_base_dir/opt/zimbra/jetty_base/common/lib/jaxb-api-2.3.1.jar");
        cpy_file("build/dist/jaxws-api-2.3.1.jar",                                   "$stage_base_dir/opt/zimbra/jetty_base/common/lib/jaxws-api-2.3.1.jar");
        cpy_file("build/dist/saaj-impl-1.5.1.jar",                                   "$stage_base_dir/opt/zimbra/lib/ext-common/saaj-impl-1.5.1.jar");
-       cpy_file("build/dist/jetty-servlets-9.4.18.v20190429.jar",                   "$stage_base_dir/opt/zimbra/jetty/webapps/service/WEB-INF/lib/jetty-servlets-9.4.18.v20190429.jar");
-       cpy_file("build/dist/jetty-servlet-9.4.18.v20190429.jar",                    "$stage_base_dir/opt/zimbra/jetty/webapps/service/WEB-INF/lib/jetty-servlet-9.4.18.v20190429.jar");
        return ["."];
 }
 


### PR DESCRIPTION
Fixed issue faced while installing build created from feature/jetty9.4 branch.
Removed the lines copying jetty-servlets and jetty-servlet to service/WEB-INF/lib this now happens as part of service war.

Verified that the ZCS installer created with these changes installs without any issue.
