### PR TITLE
ZBUG-1148:Loosing table format with owasp sanitizer

### DIFF
--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -190,7 +190,7 @@ sub stage_zimbra_core_lib($)
         cpy_file("build/dist/neethi-3.0.2.jar",                                     "$stage_base_dir/opt/zimbra/lib/jars/neethi-3.0.2.jar");
         cpy_file("build/dist/nekohtml-1.9.13.1z.jar",                               "$stage_base_dir/opt/zimbra/lib/jars/nekohtml-1.9.13.1z.jar");
         cpy_file("build/dist/oauth-20100527.jar",                                   "$stage_base_dir/opt/zimbra/lib/jars/oauth-20100527.jar");
-        cpy_file("build/dist/owasp-java-html-sanitizer-20160924.1.jar",             "$stage_base_dir/opt/zimbra/lib/jars/owasp-java-html-sanitizer-20160924.1.jar");
+        cpy_file("build/dist/owasp-java-html-sanitizer-20160924.1z.jar",             "$stage_base_dir/opt/zimbra/lib/jars/owasp-java-html-sanitizer-20160924.1z.jar");
         cpy_file("build/dist/antisamy-1.5.3.jar",                                   "$stage_base_dir/opt/zimbra/lib/jars/antisamy-1.5.3.jar");
         cpy_file("build/dist/batik-css-1.7.jar",                                    "$stage_base_dir/opt/zimbra/lib/jars/batik-css-1.7.jar");
         cpy_file("build/dist/batik-i18n-1.9.jar",                                   "$stage_base_dir/opt/zimbra/lib/jars/batik-i18n-1.9.jar");
@@ -295,6 +295,7 @@ sub stage_zimbra_store_lib($)
        cpy_file("build/dist/ant-1.7.0-ziputil-patched.jar",                         "$stage_base_dir/opt/zimbra/jetty_base/common/lib/ant-1.7.0-ziputil-patched.jar");
        cpy_file("build/dist/ical4j-0.9.16-patched.jar",                             "$stage_base_dir/opt/zimbra/jetty_base/common/lib/ical4j-0.9.16-patched.jar");
        cpy_file("build/dist/nekohtml-1.9.13.1z.jar",                                "$stage_base_dir/opt/zimbra/jetty_base/common/lib/nekohtml-1.9.13.1z.jar");
+       cpy_file("build/dist/owasp-java-html-sanitizer-20160924.1z.jar",             "$stage_base_dir/opt/zimbra/jetty_base/common/lib/owasp-java-html-sanitizer-20160924.1z.jar");
        cpy_file("build/dist/zmzimbratozimbramig-8.7.jar",                           "$stage_base_dir/opt/zimbra/lib/jars/zmzimbratozimbramig.jar");
        cpy_file("build/dist/jcharset-2.0.jar",                                      "$stage_base_dir/opt/zimbra/jetty_base/common/endorsed/jcharset.jar");
        cpy_file("build/dist/java-semver-0.9.0.jar",                                 "$stage_base_dir/opt/zimbra/jetty_base/common/lib/java-semver-0.9.0.jar");


### PR DESCRIPTION
Upgrading OWASP library to latest version, which resolves ZBUG-1148
Added fix for ZCS-7497 in new owasp library

Ref PRs:
https://github.com/Zimbra/java-html-sanitizer-release-20190610.1/pull/1
https://github.com/Zimbra/zm-build/pull/154
https://github.com/Zimbra/zm-mailbox/pull/963