### PR TITLE
ZCS-8016: updating commons fileupload version from 1.2.2 to 1.4

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -33,7 +33,7 @@
     <dependency org="commons-codec" name="commons-codec" rev="1.7"/>
     <dependency org="commons-collections" name="commons-collections" rev="3.2.2"/>
     <dependency org="commons-dbcp" name="commons-dbcp" rev="1.4"/>
-    <dependency org="commons-fileupload" name="commons-fileupload" rev="1.2.2"/>
+    <dependency org="commons-fileupload" name="commons-fileupload" rev="1.4"/>
     <dependency org="commons-io" name="commons-io" rev="1.4"/>
     <dependency org="commons-lang" name="commons-lang" rev="2.6"/>
     <dependency org="commons-logging" name="commons-logging" rev="1.1.1"/>

--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -117,7 +117,7 @@ sub stage_zimbra_core_lib($)
         cpy_file("build/dist/commons-compress-1.19.jar",                            "$stage_base_dir/opt/zimbra/lib/jars/commons-compress-1.19.jar");
         cpy_file("build/dist/commons-csv-1.2.jar",                                  "$stage_base_dir/opt/zimbra/lib/jars/commons-csv-1.2.jar");
         cpy_file("build/dist/commons-dbcp-1.4.jar",                                 "$stage_base_dir/opt/zimbra/lib/jars/commons-dbcp-1.4.jar");
-        cpy_file("build/dist/commons-fileupload-1.2.2.jar",                         "$stage_base_dir/opt/zimbra/lib/jars/commons-fileupload-1.2.2.jar");
+        cpy_file("build/dist/commons-fileupload-1.4.jar",                           "$stage_base_dir/opt/zimbra/lib/jars/commons-fileupload-1.4.jar");
         cpy_file("build/dist/commons-io-1.4.jar",                                   "$stage_base_dir/opt/zimbra/lib/jars/commons-io-1.4.jar");
         cpy_file("build/dist/commons-lang-2.6.jar",                                 "$stage_base_dir/opt/zimbra/lib/jars/commons-lang-2.6.jar");
         cpy_file("build/dist/commons-net-3.3.jar",                                  "$stage_base_dir/opt/zimbra/lib/jars/commons-net-3.3.jar");
@@ -255,7 +255,7 @@ sub stage_zimbra_store_lib($)
        cpy_file("build/dist/commons-collections-3.2.2.jar",                         "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-collections-3.2.2.jar");
        cpy_file("build/dist/commons-compress-1.19.jar",                             "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-compress-1.19.jar");
        cpy_file("build/dist/commons-dbcp-1.4.jar",                                  "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-dbcp-1.4.jar");
-       cpy_file("build/dist/commons-fileupload-1.2.2.jar",                          "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-fileupload-1.2.2.jar");
+       cpy_file("build/dist/commons-fileupload-1.4.jar",                            "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-fileupload-1.4.jar");
        cpy_file("build/dist/commons-io-1.4.jar",                                    "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-io-1.4.jar");
        cpy_file("build/dist/commons-lang-2.6.jar",                                  "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-lang-2.6.jar");
        cpy_file("build/dist/commons-logging-1.1.1.jar",                             "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-logging-1.1.1.jar");


### PR DESCRIPTION
Issue:
commons-fileupload older version have vulnerabilities in older version.

Fix:
Updating version from 1.2.2 to 1.4

Related PRs:
https://github.com/Zimbra/zm-mailbox/pull/980
https://github.com/Zimbra/zm-genesis/pull/40
https://github.com/Zimbra/zm-soap-harness/pull/93
https://github.com/Zimbra/zm-taglib/pull/33
https://github.com/Zimbra/zm-clientuploader-store/pull/3
https://github.com/Zimbra/zm-clam-scanner-store/pull/2
