### PR TITLE
ZCS-8013: Third party vulnerabilities in commons-compress

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -61,7 +61,7 @@
     <dependency org="net.spy" name="spymemcached" rev="2.12.1" transitive="false"/>
     <dependency org="oauth" name="oauth" rev="1.4"/>
     <dependency org="org.antlr" name="antlr" rev="3.2"/>
-    <dependency org="org.apache.commons" name="commons-compress" rev="1.10"/>
+    <dependency org="org.apache.commons" name="commons-compress" rev="1.19"/>
     <dependency org="org.apache.commons" name="commons-csv" rev="1.2"/>
     <dependency org="org.apache.commons" name="commons-pool2" rev="2.4.2"/>
     <dependency org="org.apache.curator" name="curator-client" rev="2.0.1-incubating"/>

--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -114,7 +114,7 @@ sub stage_zimbra_core_lib($)
         cpy_file("build/dist/commons-cli-1.2.jar",                                  "$stage_base_dir/opt/zimbra/lib/jars/commons-cli-1.2.jar");
         cpy_file("build/dist/commons-codec-1.7.jar",                                "$stage_base_dir/opt/zimbra/lib/jars/commons-codec-1.7.jar");
         cpy_file("build/dist/commons-collections-3.2.2.jar",                        "$stage_base_dir/opt/zimbra/lib/jars/commons-collections-3.2.2.jar");
-        cpy_file("build/dist/commons-compress-1.10.jar",                            "$stage_base_dir/opt/zimbra/lib/jars/commons-compress-1.10.jar");
+        cpy_file("build/dist/commons-compress-1.19.jar",                            "$stage_base_dir/opt/zimbra/lib/jars/commons-compress-1.19.jar");
         cpy_file("build/dist/commons-csv-1.2.jar",                                  "$stage_base_dir/opt/zimbra/lib/jars/commons-csv-1.2.jar");
         cpy_file("build/dist/commons-dbcp-1.4.jar",                                 "$stage_base_dir/opt/zimbra/lib/jars/commons-dbcp-1.4.jar");
         cpy_file("build/dist/commons-fileupload-1.2.2.jar",                         "$stage_base_dir/opt/zimbra/lib/jars/commons-fileupload-1.2.2.jar");
@@ -253,7 +253,7 @@ sub stage_zimbra_store_lib($)
        cpy_file("build/dist/commons-cli-1.2.jar",                                   "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-cli-1.2.jar");
        cpy_file("build/dist/commons-codec-1.7.jar",                                 "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-codec-1.7.jar");
        cpy_file("build/dist/commons-collections-3.2.2.jar",                         "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-collections-3.2.2.jar");
-       cpy_file("build/dist/commons-compress-1.10.jar",                             "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-compress-1.10.jar");
+       cpy_file("build/dist/commons-compress-1.19.jar",                             "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-compress-1.19.jar");
        cpy_file("build/dist/commons-dbcp-1.4.jar",                                  "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-dbcp-1.4.jar");
        cpy_file("build/dist/commons-fileupload-1.2.2.jar",                          "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-fileupload-1.2.2.jar");
        cpy_file("build/dist/commons-io-1.4.jar",                                    "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-io-1.4.jar");


### PR DESCRIPTION
Issue:  vulnerabilities in existing commons-compress jar 1.10
Fix: Upgrade commons-compress jar to the latest version 1.19

Related PRs:
https://github.com/Zimbra/zm-mailbox/pull/983
https://github.com/Zimbra/zm-genesis/pull/41
https://github.com/Zimbra/zm-soap-harness/pull/95