### PR TITLE
ZCS-8011: Third party vulnerabilities in Jackson databind

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -86,9 +86,9 @@
     <dependency org="org.bouncycastle" name="bcmail-jdk15on" rev="1.55"/>
     <dependency org="org.bouncycastle" name="bcpkix-jdk15on" rev="1.55"/>
     <dependency org="org.bouncycastle" name="bcprov-jdk15on" rev="1.55"/>
-    <dependency org="com.fasterxml.jackson.core" name="jackson-core" rev="2.9.2"/>
-    <dependency org="com.fasterxml.jackson.core" name="jackson-annotations" rev="2.9.2"/>
-    <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.9.2"/>
+    <dependency org="com.fasterxml.jackson.core" name="jackson-core" rev="2.10.1"/>
+    <dependency org="com.fasterxml.jackson.core" name="jackson-annotations" rev="2.10.1"/>
+    <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.10.1"/>
     <dependency org="com.fasterxml.jackson.dataformat" name="jackson-dataformat-smile" rev="2.9.2" />
     <dependency org="com.fasterxml.jackson.module" name="jackson-module-jaxb-annotations" rev="2.8.9"/>
     <dependency org="org.codehaus.woodstox" name="stax2-api" rev="3.1.1"/>

--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -143,9 +143,9 @@ sub stage_zimbra_core_lib($)
         cpy_file("build/dist/httpmime-4.3.1.jar",                                   "$stage_base_dir/opt/zimbra/lib/jars/httpmime-4.3.1.jar");
         cpy_file("build/dist/ical4j-0.9.16-patched.jar",                            "$stage_base_dir/opt/zimbra/lib/jars/ical4j-0.9.16-patched.jar");
         cpy_file("build/dist/icu4j-4.8.1.1.jar",                                    "$stage_base_dir/opt/zimbra/lib/jars/icu4j-4.8.1.1.jar");
-        cpy_file("build/dist/jackson-core-2.9.2.jar",                               "$stage_base_dir/opt/zimbra/lib/jars/jackson-core-2.9.2.jar");
-        cpy_file("build/dist/jackson-annotations-2.9.2.jar",                        "$stage_base_dir/opt/zimbra/lib/jars/jackson-annotations-2.9.2.jar");
-        cpy_file("build/dist/jackson-databind-2.9.2.jar",                           "$stage_base_dir/opt/zimbra/lib/jars/jackson-databind-2.9.2.jar");
+        cpy_file("build/dist/jackson-core-2.10.1.jar",                              "$stage_base_dir/opt/zimbra/lib/jars/jackson-core-2.10.1.jar");
+        cpy_file("build/dist/jackson-annotations-2.10.1.jar",                       "$stage_base_dir/opt/zimbra/lib/jars/jackson-annotations-2.10.1.jar");
+        cpy_file("build/dist/jackson-databind-2.10.1.jar",                          "$stage_base_dir/opt/zimbra/lib/jars/jackson-databind-2.10.1.jar");
         cpy_file("build/dist/jackson-dataformat-smile-2.9.2.jar",                   "$stage_base_dir/opt/zimbra/lib/jars/jackson-dataformat-smile-2.9.2.jar");
         cpy_file("build/dist/jackson-module-jaxb-annotations-2.8.9.jar",            "$stage_base_dir/opt/zimbra/lib/jars/jackson-module-jaxb-annotations-2.8.9.jar");
         cpy_file("build/dist/jamm-0.2.5.jar",                                       "$stage_base_dir/opt/zimbra/lib/jars/jamm-0.2.5.jar");


### PR DESCRIPTION
Issue: Third-party vulnerabilities in Jackson library
Fix: Upgrade the Jackson library to the latest version

Related PRs:
https://github.com/Zimbra/zm-oauth-social/pull/54
https://github.com/Zimbra/zm-mailbox/pull/984
https://github.com/Zimbra/zm-gql/pull/54
https://github.com/Zimbra/zm-gql-admin/pull/1
https://github.com/Zimbra/zm-network-gql/pull/5