### PR TITLE
ZCS-8017: updating guava version to 28.1-jre from 23.0

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -9,7 +9,7 @@
     <dependency org="ch.ethz.ganymed" name="ganymed-ssh2" rev="build210"/>
     <dependency org="com.101tec" name="zkclient" rev="0.1.0"/>
     <dependency org="com.github.stephenc" name="jamm" rev="0.2.5"/>
-    <dependency org="com.google.guava" name="guava" rev="23.0"/>
+    <dependency org="com.google.guava" name="guava" rev="28.1-jre"/>
     <dependency org="com.googlecode.concurrentlinkedhashmap" name="concurrentlinkedhashmap-lru" rev="1.3.1"/>
     <dependency org="com.ibm.icu" name="icu4j" rev="4.8.1.1"/>
     <dependency org="com.jcraft" name="jzlib" rev="1.0.7"/>

--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -134,7 +134,7 @@ sub stage_zimbra_core_lib($)
         cpy_file("build/dist/ganymed-ssh2-build210.jar",                            "$stage_base_dir/opt/zimbra/lib/jars/ganymed-ssh2-build210.jar");
         cpy_file("build/dist/gifencoder-0.9.jar",                                   "$stage_base_dir/opt/zimbra/lib/jars/gifencoder-0.9.jar");
         cpy_file("build/dist/gmbal-api-only-2.2.6.jar",                             "$stage_base_dir/opt/zimbra/lib/jars/gmbal-api-only-2.2.6.jar");
-        cpy_file("build/dist/guava-23.0.jar",                                       "$stage_base_dir/opt/zimbra/lib/jars/guava-23.0.jar");
+        cpy_file("build/dist/guava-28.1-jre.jar",                                   "$stage_base_dir/opt/zimbra/lib/jars/guava-28.1-jre.jar");
         cpy_file("build/dist/helix-core-0.6.1-incubating.jar",                      "$stage_base_dir/opt/zimbra/lib/jars/helix-core-0.6.1-incubating.jar");
         cpy_file("build/dist/httpasyncclient-4.1.4.jar",                            "$stage_base_dir/opt/zimbra/lib/jars/httpasyncclient-4.1.4.jar");
         cpy_file("build/dist/httpclient-4.5.8.jar",                                 "$stage_base_dir/opt/zimbra/lib/jars/httpclient-4.5.8.jar");
@@ -264,7 +264,7 @@ sub stage_zimbra_store_lib($)
        cpy_file("build/dist/concurrentlinkedhashmap-lru-1.3.1.jar",                 "$stage_base_dir/opt/zimbra/jetty_base/common/lib/concurrentlinkedhashmap-lru-1.3.1.jar");
        cpy_file("build/dist/dom4j-2.1.1.jar",                                       "$stage_base_dir/opt/zimbra/jetty_base/common/lib/dom4j-2.1.1.jar");
        cpy_file("build/dist/ganymed-ssh2-build210.jar",                             "$stage_base_dir/opt/zimbra/jetty_base/common/lib/ganymed-ssh2-build210.jar");
-       cpy_file("build/dist/guava-23.0.jar",                                        "$stage_base_dir/opt/zimbra/jetty_base/common/lib/guava-23.0.jar");
+       cpy_file("build/dist/guava-28.1-jre.jar",                                    "$stage_base_dir/opt/zimbra/jetty_base/common/lib/guava-28.1-jre.jar");
        cpy_file("build/dist/httpasyncclient-4.1.4.jar",                             "$stage_base_dir/opt/zimbra/jetty_base/common/lib/httpasyncclient-4.1.4.jar");
        cpy_file("build/dist/httpclient-4.5.8.jar",                                  "$stage_base_dir/opt/zimbra/jetty_base/common/lib/httpclient-4.5.8.jar");
        cpy_file("build/dist/httpcore-4.4.11.jar",                                    "$stage_base_dir/opt/zimbra/jetty_base/common/lib/httpcore-4.4.11.jar");


### PR DESCRIPTION
Issue:
Vulnerabilities in older version 23.0 of Guava.

Fix:
Update version to 28.1-jre