### PR TITLE
ZCS-8010: updating bouncycastle version to 1.64 from 1.55

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -84,9 +84,9 @@
     <dependency org="org.apache.neethi" name="neethi" rev="3.0.2"/>
     <dependency org="org.apache.ws.xmlschema" name="xmlschema-core" rev="2.0.3"/>
     <dependency org="org.apache.zookeeper" name="zookeeper" rev="3.4.5"/>
-    <dependency org="org.bouncycastle" name="bcmail-jdk15on" rev="1.55"/>
-    <dependency org="org.bouncycastle" name="bcpkix-jdk15on" rev="1.55"/>
-    <dependency org="org.bouncycastle" name="bcprov-jdk15on" rev="1.55"/>
+    <dependency org="org.bouncycastle" name="bcmail-jdk15on" rev="1.64"/>
+    <dependency org="org.bouncycastle" name="bcpkix-jdk15on" rev="1.64"/>
+    <dependency org="org.bouncycastle" name="bcprov-jdk15on" rev="1.64"/>
     <dependency org="com.fasterxml.jackson.core" name="jackson-core" rev="2.10.1"/>
     <dependency org="com.fasterxml.jackson.core" name="jackson-annotations" rev="2.10.1"/>
     <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.10.1"/>

--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -110,7 +110,7 @@ sub stage_zimbra_core_lib($)
         cpy_file("build/dist/apache-jsieve-core-0.5.jar",                           "$stage_base_dir/opt/zimbra/lib/jars/apache-jsieve-core-0.5.jar");
         cpy_file("build/dist/apache-log4j-extras-1.0.jar",                          "$stage_base_dir/opt/zimbra/lib/jars/apache-log4j-extras-1.0.jar");
         cpy_file("build/dist/asm-3.3.1.jar",                                        "$stage_base_dir/opt/zimbra/lib/jars/asm-3.3.1.jar");
-        cpy_file("build/dist/bcprov-jdk15on-1.55.jar",                              "$stage_base_dir/opt/zimbra/lib/jars/bcprov-jdk15on-1.55.jar");
+        cpy_file("build/dist/bcprov-jdk15on-1.64.jar",                              "$stage_base_dir/opt/zimbra/lib/jars/bcprov-jdk15on-1.64.jar");
         cpy_file("build/dist/commons-cli-1.2.jar",                                  "$stage_base_dir/opt/zimbra/lib/jars/commons-cli-1.2.jar");
         cpy_file("build/dist/commons-codec-1.7.jar",                                "$stage_base_dir/opt/zimbra/lib/jars/commons-codec-1.7.jar");
         cpy_file("build/dist/commons-collections-3.2.2.jar",                        "$stage_base_dir/opt/zimbra/lib/jars/commons-collections-3.2.2.jar");
@@ -239,13 +239,13 @@ sub stage_zimbra_store_lib($)
 {
    my $stage_base_dir = shift;
 
-       cpy_file("build/dist/bcpkix-jdk15on-1.55.jar",                               "$stage_base_dir/opt/zimbra/jetty_base/common/lib/bcpkix-jdk15on-1.55.jar");
-       cpy_file("build/dist/bcmail-jdk15on-1.55.jar",                               "$stage_base_dir/opt/zimbra/lib/ext-common/bcmail-jdk15on-1.55.jar");
+       cpy_file("build/dist/bcpkix-jdk15on-1.64.jar",                               "$stage_base_dir/opt/zimbra/jetty_base/common/lib/bcpkix-jdk15on-1.64.jar");
+       cpy_file("build/dist/bcmail-jdk15on-1.64.jar",                               "$stage_base_dir/opt/zimbra/lib/ext-common/bcmail-jdk15on-1.64.jar");
        cpy_file("build/dist/zmzimbratozimbramig-8.7.jar",                           "$stage_base_dir/opt/zimbra/lib/jars/zmzimbratozimbramig.jar");
        cpy_file("build/dist/jcharset-2.0.jar",                                      "$stage_base_dir/opt/zimbra/jetty_base/common/endorsed/jcharset.jar");
        cpy_file("build/dist/zimbra-charset.jar",                                    "$stage_base_dir/opt/zimbra/jetty_base/common/endorsed/zimbra-charset.jar");
        cpy_file("build/dist/apache-log4j-extras-1.0.jar",                           "$stage_base_dir/opt/zimbra/jetty_base/common/lib/apache-log4j-extras-1.0.jar");
-       cpy_file("build/dist/bcprov-jdk15on-1.55.jar",                               "$stage_base_dir/opt/zimbra/jetty_base/common/lib/bcprov-jdk15on-1.55.jar");
+       cpy_file("build/dist/bcprov-jdk15on-1.64.jar",                               "$stage_base_dir/opt/zimbra/jetty_base/common/lib/bcprov-jdk15on-1.64.jar");
        cpy_file("build/dist/commons-cli-1.2.jar",                                   "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-cli-1.2.jar");
        cpy_file("build/dist/commons-codec-1.7.jar",                                 "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-codec-1.7.jar");
        cpy_file("build/dist/commons-collections-3.2.2.jar",                         "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-collections-3.2.2.jar");


### PR DESCRIPTION
Issue:
Vulnerabilities in older version 1.55 of bouncy castle.

Fix:
Update version to 1.64