### PR TITLE
ZCS-8009: Third party vulnerabilities in Smack

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -49,8 +49,6 @@
     <dependency org="jaxen" name="jaxen" rev="1.1.3"/>
     <dependency org="jcs" name="jcs" rev="1.3"/>
     <dependency org="jdom" name="jdom" rev="1.1"/>
-    <dependency org="jivesoftware" name="smack" rev="3.1.0"/>
-    <dependency org="jivesoftware" name="smackx" rev="3.1.0"/>
     <dependency org="jline" name="jline" rev="0.9.93"/>
     <dependency org="log4j" name="apache-log4j-extras" rev="1.0"/>
     <dependency org="net.freeutils" name="jcharset" rev="2.0"/>
@@ -112,8 +110,6 @@
     <dependency org="org.freemarker" name="freemarker" rev="2.3.19"/>
     <dependency org="org.glassfish.gmbal" name="gmbal-api-only" rev="2.2.6"/>
     <dependency org="org.gnu.inet" name="libidn" rev="1.24"/>
-    <dependency org="org.igniterealtime.smack" name="smackx-debug" rev="3.2.1"/>
-    <dependency org="org.igniterealtime.smack" name="smackx-jingle" rev="3.2.1"/>
     <dependency org="org.jfree" name="jcommon" rev="1.0.21"/>
     <dependency org="org.jfree" name="jfreechart" rev="1.0.15"/>
     <dependency org="org.json" name="json" rev="20090211"/>

--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -198,10 +198,6 @@ sub stage_zimbra_core_lib($)
         cpy_file("build/dist/policy-2.3.jar",                                       "$stage_base_dir/opt/zimbra/lib/jars/policy-2.3.jar");
         cpy_file("build/dist/slf4j-api-1.6.4.jar",                                  "$stage_base_dir/opt/zimbra/lib/jars/slf4j-api-1.6.4.jar");
         cpy_file("build/dist/slf4j-log4j12-1.6.4.jar",                              "$stage_base_dir/opt/zimbra/lib/jars/slf4j-log4j12-1.6.4.jar");
-        cpy_file("build/dist/smack-3.1.0.jar",                                      "$stage_base_dir/opt/zimbra/lib/jars/smack-3.1.0.jar");
-        cpy_file("build/dist/smackx-3.1.0.jar",                                     "$stage_base_dir/opt/zimbra/lib/jars/smackx-3.1.0.jar");
-        cpy_file("build/dist/smackx-debug-3.2.1.jar",                               "$stage_base_dir/opt/zimbra/lib/jars/smackx-debug-3.2.1.jar");
-        cpy_file("build/dist/smackx-jingle-3.2.1.jar",                              "$stage_base_dir/opt/zimbra/lib/jars/smackx-jingle-3.2.1.jar");
         cpy_file("build/dist/spring-aop-5.1.10.RELEASE.jar",                        "$stage_base_dir/opt/zimbra/lib/jars/spring-aop-5.1.10.RELEASE.jar");
         cpy_file("build/dist/spring-asm-3.0.7.RELEASE.jar",                         "$stage_base_dir/opt/zimbra/lib/jars/spring-asm-3.0.7.RELEASE.jar");
         cpy_file("build/dist/spring-beans-5.1.10.RELEASE.jar",                      "$stage_base_dir/opt/zimbra/lib/jars/spring-beans-5.1.10.RELEASE.jar");


### PR DESCRIPTION
Issue: Third-party vulnerabilities in Smack.
Fix: Removed these jar files as it's not used anywhere in the codebase.
