### PR TITLE
feature/ZCS-10060 : Upgraded SSH client library

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -6,8 +6,8 @@
     <dependency org="ant" name="ant" rev="1.6.5"/>
     <dependency org="ant-contrib" name="ant-contrib" rev="1.0b2"/>
     <dependency org="org.ow2.asm" name="asm" rev="8.0.1"/>
-    <dependency org="org.jenkins-ci" name="trilead-ssh2" rev="build-217-jenkins-27" />
-    <dependency org="net.i2p.crypto" name="eddsa" rev="0.3.0" />
+    <dependency org="org.apache.sshd" name="sshd-common" rev="2.5.1"/>
+    <dependency org="org.apache.sshd" name="sshd-core" rev="2.5.1"/>
     <dependency org="com.101tec" name="zkclient" rev="0.1.0"/>
     <dependency org="com.github.stephenc" name="jamm" rev="0.2.5"/>
     <dependency org="com.google.guava" name="guava" rev="28.1-jre"/>

--- a/ivy.xml
+++ b/ivy.xml
@@ -6,8 +6,8 @@
     <dependency org="ant" name="ant" rev="1.6.5"/>
     <dependency org="ant-contrib" name="ant-contrib" rev="1.0b2"/>
     <dependency org="org.ow2.asm" name="asm" rev="8.0.1"/>
-    <dependency org="org.apache.sshd" name="sshd-common" rev="2.5.1"/>
-    <dependency org="org.apache.sshd" name="sshd-core" rev="2.5.1"/>
+    <dependency org="org.apache.sshd" name="sshd-common" rev="2.6.0"/>
+    <dependency org="org.apache.sshd" name="sshd-core" rev="2.6.0"/>
     <dependency org="com.101tec" name="zkclient" rev="0.1.0"/>
     <dependency org="com.github.stephenc" name="jamm" rev="0.2.5"/>
     <dependency org="com.google.guava" name="guava" rev="28.1-jre"/>

--- a/ivy.xml
+++ b/ivy.xml
@@ -6,7 +6,8 @@
     <dependency org="ant" name="ant" rev="1.6.5"/>
     <dependency org="ant-contrib" name="ant-contrib" rev="1.0b2"/>
     <dependency org="org.ow2.asm" name="asm" rev="8.0.1"/>
-    <dependency org="ch.ethz.ganymed" name="ganymed-ssh2" rev="build210"/>
+    <dependency org="org.jenkins-ci" name="trilead-ssh2" rev="build-217-jenkins-27" />
+    <dependency org="net.i2p.crypto" name="eddsa" rev="0.3.0" />
     <dependency org="com.101tec" name="zkclient" rev="0.1.0"/>
     <dependency org="com.github.stephenc" name="jamm" rev="0.2.5"/>
     <dependency org="com.google.guava" name="guava" rev="28.1-jre"/>

--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -131,7 +131,8 @@ sub stage_zimbra_core_lib($)
         cpy_file("build/dist/cxf-core-3.3.4.jar",                                   "$stage_base_dir/opt/zimbra/lib/jars/cxf-core-3.3.4.jar");
         cpy_file("build/dist/dom4j-2.1.1.jar",                                      "$stage_base_dir/opt/zimbra/lib/jars/dom4j-2.1.1.jar");
         cpy_file("build/dist/freemarker-2.3.19.jar",                                "$stage_base_dir/opt/zimbra/lib/jars/freemarker-2.3.19.jar");
-        cpy_file("build/dist/ganymed-ssh2-build210.jar",                            "$stage_base_dir/opt/zimbra/lib/jars/ganymed-ssh2-build210.jar");
+        cpy_file("build/dist/trilead-ssh2-build-217-jenkins-27.jar",                "$stage_base_dir/opt/zimbra/lib/jars/trilead-ssh2-build-217-jenkins-27.jar");
+        cpy_file("build/dist/eddsa-0.3.0.jar",                                      "$stage_base_dir/opt/zimbra/lib/jars/eddsa-0.3.0.jar");
         cpy_file("build/dist/gifencoder-0.9.jar",                                   "$stage_base_dir/opt/zimbra/lib/jars/gifencoder-0.9.jar");
         cpy_file("build/dist/gmbal-api-only-2.2.6.jar",                             "$stage_base_dir/opt/zimbra/lib/jars/gmbal-api-only-2.2.6.jar");
         cpy_file("build/dist/guava-28.1-jre.jar",                                   "$stage_base_dir/opt/zimbra/lib/jars/guava-28.1-jre.jar");
@@ -258,7 +259,8 @@ sub stage_zimbra_store_lib($)
        cpy_file("build/dist/commons-pool-1.6.jar",                                  "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-pool-1.6.jar");
        cpy_file("build/dist/concurrentlinkedhashmap-lru-1.3.1.jar",                 "$stage_base_dir/opt/zimbra/jetty_base/common/lib/concurrentlinkedhashmap-lru-1.3.1.jar");
        cpy_file("build/dist/dom4j-2.1.1.jar",                                       "$stage_base_dir/opt/zimbra/jetty_base/common/lib/dom4j-2.1.1.jar");
-       cpy_file("build/dist/ganymed-ssh2-build210.jar",                             "$stage_base_dir/opt/zimbra/jetty_base/common/lib/ganymed-ssh2-build210.jar");
+       cpy_file("build/dist/trilead-ssh2-build-217-jenkins-27.jar",                 "$stage_base_dir/opt/zimbra/jetty_base/common/lib/trilead-ssh2-build-217-jenkins-27.jar");
+       cpy_file("build/dist/eddsa-0.3.0.jar",                                       "$stage_base_dir/opt/zimbra/jetty_base/common/lib/eddsa-0.3.0.jar");
        cpy_file("build/dist/guava-28.1-jre.jar",                                    "$stage_base_dir/opt/zimbra/jetty_base/common/lib/guava-28.1-jre.jar");
        cpy_file("build/dist/httpasyncclient-4.1.4.jar",                             "$stage_base_dir/opt/zimbra/jetty_base/common/lib/httpasyncclient-4.1.4.jar");
        cpy_file("build/dist/httpclient-4.5.8.jar",                                  "$stage_base_dir/opt/zimbra/jetty_base/common/lib/httpclient-4.5.8.jar");

--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -259,6 +259,7 @@ sub stage_zimbra_store_lib($)
        cpy_file("build/dist/dom4j-2.1.1.jar",                                       "$stage_base_dir/opt/zimbra/jetty_base/common/lib/dom4j-2.1.1.jar");
        cpy_file("build/dist/sshd-common-2.5.1.jar",                                 "$stage_base_dir/opt/zimbra/jetty_base/common/lib/sshd-common-2.5.1.jar");
        cpy_file("build/dist/sshd-core-2.5.1.jar",                                   "$stage_base_dir/opt/zimbra/jetty_base/common/lib/sshd-core-2.5.1.jar");
+       cpy_file("build/dist/slf4j-api-1.6.4.jar",                                   "$stage_base_dir/opt/zimbra/jetty_base/common/lib/slf4j-api-1.6.4.jar");
        cpy_file("build/dist/guava-28.1-jre.jar",                                    "$stage_base_dir/opt/zimbra/jetty_base/common/lib/guava-28.1-jre.jar");
        cpy_file("build/dist/httpasyncclient-4.1.4.jar",                             "$stage_base_dir/opt/zimbra/jetty_base/common/lib/httpasyncclient-4.1.4.jar");
        cpy_file("build/dist/httpclient-4.5.8.jar",                                  "$stage_base_dir/opt/zimbra/jetty_base/common/lib/httpclient-4.5.8.jar");

--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -131,8 +131,6 @@ sub stage_zimbra_core_lib($)
         cpy_file("build/dist/cxf-core-3.3.4.jar",                                   "$stage_base_dir/opt/zimbra/lib/jars/cxf-core-3.3.4.jar");
         cpy_file("build/dist/dom4j-2.1.1.jar",                                      "$stage_base_dir/opt/zimbra/lib/jars/dom4j-2.1.1.jar");
         cpy_file("build/dist/freemarker-2.3.19.jar",                                "$stage_base_dir/opt/zimbra/lib/jars/freemarker-2.3.19.jar");
-        cpy_file("build/dist/trilead-ssh2-build-217-jenkins-27.jar",                "$stage_base_dir/opt/zimbra/lib/jars/trilead-ssh2-build-217-jenkins-27.jar");
-        cpy_file("build/dist/eddsa-0.3.0.jar",                                      "$stage_base_dir/opt/zimbra/lib/jars/eddsa-0.3.0.jar");
         cpy_file("build/dist/gifencoder-0.9.jar",                                   "$stage_base_dir/opt/zimbra/lib/jars/gifencoder-0.9.jar");
         cpy_file("build/dist/gmbal-api-only-2.2.6.jar",                             "$stage_base_dir/opt/zimbra/lib/jars/gmbal-api-only-2.2.6.jar");
         cpy_file("build/dist/guava-28.1-jre.jar",                                   "$stage_base_dir/opt/zimbra/lib/jars/guava-28.1-jre.jar");
@@ -259,8 +257,8 @@ sub stage_zimbra_store_lib($)
        cpy_file("build/dist/commons-pool-1.6.jar",                                  "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-pool-1.6.jar");
        cpy_file("build/dist/concurrentlinkedhashmap-lru-1.3.1.jar",                 "$stage_base_dir/opt/zimbra/jetty_base/common/lib/concurrentlinkedhashmap-lru-1.3.1.jar");
        cpy_file("build/dist/dom4j-2.1.1.jar",                                       "$stage_base_dir/opt/zimbra/jetty_base/common/lib/dom4j-2.1.1.jar");
-       cpy_file("build/dist/trilead-ssh2-build-217-jenkins-27.jar",                 "$stage_base_dir/opt/zimbra/jetty_base/common/lib/trilead-ssh2-build-217-jenkins-27.jar");
-       cpy_file("build/dist/eddsa-0.3.0.jar",                                       "$stage_base_dir/opt/zimbra/jetty_base/common/lib/eddsa-0.3.0.jar");
+       cpy_file("build/dist/sshd-common-2.5.1.jar",                                 "$stage_base_dir/opt/zimbra/jetty_base/common/lib/sshd-common-2.5.1.jar");
+       cpy_file("build/dist/sshd-core-2.5.1.jar",                                   "$stage_base_dir/opt/zimbra/jetty_base/common/lib/sshd-core-2.5.1.jar");
        cpy_file("build/dist/guava-28.1-jre.jar",                                    "$stage_base_dir/opt/zimbra/jetty_base/common/lib/guava-28.1-jre.jar");
        cpy_file("build/dist/httpasyncclient-4.1.4.jar",                             "$stage_base_dir/opt/zimbra/jetty_base/common/lib/httpasyncclient-4.1.4.jar");
        cpy_file("build/dist/httpclient-4.5.8.jar",                                  "$stage_base_dir/opt/zimbra/jetty_base/common/lib/httpclient-4.5.8.jar");

--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -257,8 +257,8 @@ sub stage_zimbra_store_lib($)
        cpy_file("build/dist/commons-pool-1.6.jar",                                  "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-pool-1.6.jar");
        cpy_file("build/dist/concurrentlinkedhashmap-lru-1.3.1.jar",                 "$stage_base_dir/opt/zimbra/jetty_base/common/lib/concurrentlinkedhashmap-lru-1.3.1.jar");
        cpy_file("build/dist/dom4j-2.1.1.jar",                                       "$stage_base_dir/opt/zimbra/jetty_base/common/lib/dom4j-2.1.1.jar");
-       cpy_file("build/dist/sshd-common-2.5.1.jar",                                 "$stage_base_dir/opt/zimbra/jetty_base/common/lib/sshd-common-2.5.1.jar");
-       cpy_file("build/dist/sshd-core-2.5.1.jar",                                   "$stage_base_dir/opt/zimbra/jetty_base/common/lib/sshd-core-2.5.1.jar");
+       cpy_file("build/dist/sshd-common-2.6.0.jar",                                 "$stage_base_dir/opt/zimbra/jetty_base/common/lib/sshd-common-2.6.0.jar");
+       cpy_file("build/dist/sshd-core-2.6.0.jar",                                   "$stage_base_dir/opt/zimbra/jetty_base/common/lib/sshd-core-2.6.0.jar");
        cpy_file("build/dist/slf4j-api-1.6.4.jar",                                   "$stage_base_dir/opt/zimbra/jetty_base/common/lib/slf4j-api-1.6.4.jar");
        cpy_file("build/dist/guava-28.1-jre.jar",                                    "$stage_base_dir/opt/zimbra/jetty_base/common/lib/guava-28.1-jre.jar");
        cpy_file("build/dist/httpasyncclient-4.1.4.jar",                             "$stage_base_dir/opt/zimbra/jetty_base/common/lib/httpasyncclient-4.1.4.jar");


### PR DESCRIPTION
**Problem**: RemoteManager calls are failing with FIPS enabled.
https://jira.corp.synacor.com/browse/ZCS-10060?focusedCommentId=1419982&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-1419982

Ganymed SSH-2 offering KexAlgorithms: `diffie-hellman-group-exchange-sha1`, `diffie-hellman-group14-sha1`, `diffie-hellman-group1-sha1` , which are not allowed in FIPS mode.

**Solution** : Replaced Ganymed SSH-2 with Trilead SSH-2 , which supports KexAlgorithms allowed in FIPS mode.