### PR TITLE
ZCS-10322: LDAP Attribute for supporting Attachment Type Restrictions

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -156,6 +156,7 @@
     <dependency org="org.apache.xmlgraphics" name="batik-util" rev="1.8"/>
     <dependency org="org.apache.tika" name="tika-app" rev="1.24.1"/>
     <dependency org="eu.bitwalker" name="UserAgentUtils" rev="1.21"/>
+    <dependency org="org.apache.tika" name="tika-core" rev="1.24"/>
     <exclude org="com.noelios.restlet" module="com.noelios.restlet"/>
     <exclude org="javax.sql" module="jdbc-stdext"/>
     <exclude org="javax.transaction" module="jta"/>

--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -308,7 +308,7 @@ sub stage_zimbra_store_lib($)
        cpy_file("build/dist/jaxb-impl-2.3.1.jar",                                   "$stage_base_dir/opt/zimbra/jetty_base/common/lib/jaxb-impl-2.3.1.jar");
        cpy_file("build/dist/jaxb-api-2.3.1.jar",                                    "$stage_base_dir/opt/zimbra/jetty_base/common/lib/jaxb-api-2.3.1.jar");
        cpy_file("build/dist/jaxws-api-2.3.1.jar",                                   "$stage_base_dir/opt/zimbra/jetty_base/common/lib/jaxws-api-2.3.1.jar");
-       cpy_file("build/dist/tika-core-1.24.jar",                                    "$stage_base_dir/opt/zimbra/jetty_base/common/lib/tika-core-1.24.jar");
+       cpy_file("build/dist/tika-app-1.24.1.jar",                                   "$stage_base_dir/opt/zimbra/jetty_base/common/lib/tika-app-1.24.1.jar");
        cpy_file("build/dist/saaj-impl-1.5.1.jar",                                   "$stage_base_dir/opt/zimbra/lib/ext-common/saaj-impl-1.5.1.jar");
        cpy_file("build/dist/antisamy-1.5.8z.jar",                                   "$stage_base_dir/opt/zimbra/jetty_base/webapps/service/WEB-INF/lib/antisamy-1.5.8z.jar");
        cpy_file("build/dist/UserAgentUtils-1.21.jar",                               "$stage_base_dir/opt/zimbra/jetty_base/common/lib/UserAgentUtils-1.21.jar");

--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -230,6 +230,7 @@ sub stage_zimbra_core_lib($)
         cpy_file("build/dist/javax.annotation-api-1.2.jar",                         "$stage_base_dir/opt/zimbra/lib/jars/javax.annotation-api-1.2.jar");
         cpy_file("build/dist/apache-jsp-9.4.18.v20190429.jar",                      "$stage_base_dir/opt/zimbra/lib/jars/apache-jsp-9.4.18.v20190429.jar");
         cpy_file("build/dist/UserAgentUtils-1.21.jar",                              "$stage_base_dir/opt/zimbra/lib/jars/UserAgentUtils-1.21.jar");
+        cpy_file("build/dist/tika-core-1.24.jar",                                   "$stage_base_dir/opt/zimbra/lib/jars/tika-core-1.24.jar");
         return ["."];
 }
 
@@ -307,6 +308,7 @@ sub stage_zimbra_store_lib($)
        cpy_file("build/dist/jaxb-impl-2.3.1.jar",                                   "$stage_base_dir/opt/zimbra/jetty_base/common/lib/jaxb-impl-2.3.1.jar");
        cpy_file("build/dist/jaxb-api-2.3.1.jar",                                    "$stage_base_dir/opt/zimbra/jetty_base/common/lib/jaxb-api-2.3.1.jar");
        cpy_file("build/dist/jaxws-api-2.3.1.jar",                                   "$stage_base_dir/opt/zimbra/jetty_base/common/lib/jaxws-api-2.3.1.jar");
+       cpy_file("build/dist/tika-core-1.24.jar",                                    "$stage_base_dir/opt/zimbra/jetty_base/common/lib/tika-core-1.24.jar");
        cpy_file("build/dist/saaj-impl-1.5.1.jar",                                   "$stage_base_dir/opt/zimbra/lib/ext-common/saaj-impl-1.5.1.jar");
        cpy_file("build/dist/antisamy-1.5.8z.jar",                                   "$stage_base_dir/opt/zimbra/jetty_base/webapps/service/WEB-INF/lib/antisamy-1.5.8z.jar");
        cpy_file("build/dist/UserAgentUtils-1.21.jar",                               "$stage_base_dir/opt/zimbra/jetty_base/common/lib/UserAgentUtils-1.21.jar");


### PR DESCRIPTION
Added `tika-core` library for detecting the content-type and the file extension for the attachment.

**Related PR:**
[zm-build](https://github.com/Zimbra/zm-build/pull/180)
[zm-mailbox](https://github.com/Zimbra/zm-mailbox/pull/1132)