### PR TITLE
ZBUG-722: ed25519 support for Apache MINA SSHD

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -8,6 +8,7 @@
     <dependency org="org.ow2.asm" name="asm" rev="8.0.1"/>
     <dependency org="org.apache.sshd" name="sshd-common" rev="2.6.0"/>
     <dependency org="org.apache.sshd" name="sshd-core" rev="2.6.0"/>
+    <dependency org="net.i2p.crypto" name="eddsa" rev="0.3.0"/>
     <dependency org="com.101tec" name="zkclient" rev="0.1.0"/>
     <dependency org="com.github.stephenc" name="jamm" rev="0.2.5"/>
     <dependency org="com.google.guava" name="guava" rev="28.1-jre"/>

--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -259,6 +259,7 @@ sub stage_zimbra_store_lib($)
        cpy_file("build/dist/dom4j-2.1.1.jar",                                       "$stage_base_dir/opt/zimbra/jetty_base/common/lib/dom4j-2.1.1.jar");
        cpy_file("build/dist/sshd-common-2.6.0.jar",                                 "$stage_base_dir/opt/zimbra/jetty_base/common/lib/sshd-common-2.6.0.jar");
        cpy_file("build/dist/sshd-core-2.6.0.jar",                                   "$stage_base_dir/opt/zimbra/jetty_base/common/lib/sshd-core-2.6.0.jar");
+       cpy_file("build/dist/eddsa-0.3.0.jar",                                       "$stage_base_dir/opt/zimbra/jetty_base/common/lib/eddsa-0.3.0.jar");
        cpy_file("build/dist/slf4j-api-1.6.4.jar",                                   "$stage_base_dir/opt/zimbra/jetty_base/common/lib/slf4j-api-1.6.4.jar");
        cpy_file("build/dist/guava-28.1-jre.jar",                                    "$stage_base_dir/opt/zimbra/jetty_base/common/lib/guava-28.1-jre.jar");
        cpy_file("build/dist/httpasyncclient-4.1.4.jar",                             "$stage_base_dir/opt/zimbra/jetty_base/common/lib/httpasyncclient-4.1.4.jar");


### PR DESCRIPTION
**Problem:** 
When we use ssh-ed25519 in HostKeyAlgorithms, Apache MINA SSHD not able to communicate with OpenSSH.

**Fix:**
Apache MINA SSHD will not support ssh-ed25519  directly. To support ssh-ed25519 eddsa module must be added as an explicit dependency.

**Reference** 
https://github.com/apache/mina-sshd/blob/2fc98f7a21a7b83d2b2bc72d48a2194caa7f8fd1/docs/dependencies.md
