### PR TITLE
ZCS-10598: Switching from tika-app-1.24.1.jar to tika-core-1.24.1.jar

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -157,7 +157,7 @@
     <dependency org="org.apache.xmlgraphics" name="batik-util" rev="1.8"/>
     <dependency org="org.apache.tika" name="tika-app" rev="1.24.1"/>
     <dependency org="eu.bitwalker" name="UserAgentUtils" rev="1.21"/>
-    <dependency org="org.apache.tika" name="tika-core" rev="1.24"/>
+    <dependency org="org.apache.tika" name="tika-core" rev="1.24.1"/>
     <dependency org="org.apache.poi" name="poi-ooxml" rev="4.1.2"/>
     <dependency org="org.apache.poi" name="poi-ooxml-schemas" rev="4.1.2"/>
     <dependency org="org.apache.poi" name="poi" rev="4.1.2"/>

--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -230,7 +230,7 @@ sub stage_zimbra_core_lib($)
         cpy_file("build/dist/javax.annotation-api-1.2.jar",                         "$stage_base_dir/opt/zimbra/lib/jars/javax.annotation-api-1.2.jar");
         cpy_file("build/dist/apache-jsp-9.4.18.v20190429.jar",                      "$stage_base_dir/opt/zimbra/lib/jars/apache-jsp-9.4.18.v20190429.jar");
         cpy_file("build/dist/UserAgentUtils-1.21.jar",                              "$stage_base_dir/opt/zimbra/lib/jars/UserAgentUtils-1.21.jar");
-        cpy_file("build/dist/tika-core-1.24.jar",                                   "$stage_base_dir/opt/zimbra/lib/jars/tika-core-1.24.jar");
+        cpy_file("build/dist/tika-core-1.24.1.jar",                                 "$stage_base_dir/opt/zimbra/lib/jars/tika-core-1.24.1.jar");
         return ["."];
 }
 
@@ -309,7 +309,7 @@ sub stage_zimbra_store_lib($)
        cpy_file("build/dist/jaxb-impl-2.3.1.jar",                                   "$stage_base_dir/opt/zimbra/jetty_base/common/lib/jaxb-impl-2.3.1.jar");
        cpy_file("build/dist/jaxb-api-2.3.1.jar",                                    "$stage_base_dir/opt/zimbra/jetty_base/common/lib/jaxb-api-2.3.1.jar");
        cpy_file("build/dist/jaxws-api-2.3.1.jar",                                   "$stage_base_dir/opt/zimbra/jetty_base/common/lib/jaxws-api-2.3.1.jar");
-       cpy_file("build/dist/tika-app-1.24.1.jar",                                   "$stage_base_dir/opt/zimbra/jetty_base/common/lib/tika-app-1.24.1.jar");
+       cpy_file("build/dist/tika-core-1.24.1.jar",                                  "$stage_base_dir/opt/zimbra/jetty_base/common/lib/tika-core-1.24.1.jar");
        cpy_file("build/dist/saaj-impl-1.5.1.jar",                                   "$stage_base_dir/opt/zimbra/lib/ext-common/saaj-impl-1.5.1.jar");
        cpy_file("build/dist/antisamy-1.5.8z.jar",                                   "$stage_base_dir/opt/zimbra/jetty_base/webapps/service/WEB-INF/lib/antisamy-1.5.8z.jar");
        cpy_file("build/dist/UserAgentUtils-1.21.jar",                               "$stage_base_dir/opt/zimbra/jetty_base/common/lib/UserAgentUtils-1.21.jar");


### PR DESCRIPTION
**Fix:**
Switching from tika-app-1.24.1.jar to tika-core-1.24.jar to fix `system failure: native formatter failure` while opening doc for editing.

**Note:**
After switching from tika-app-1.24.1.jar to tika-core-1.24.jar the above exception in the description is not reproducible. Following are the observations:

In case of Ubuntu when we use `attachment_extraction_client_class=com.zimbra.cs.convert.LegacyConverterClient`, there are issues while indexing and extraction is getting failed.

```
2021-07-02 09:26:42,714 INFO  [ReIndex-0] [name=akshat@shashi-classic-m1.synacor.tk;mid=2;] index - Re-index start
2021-07-02 09:26:42,715 INFO  [ReIndex-0] [name=akshat@shashi-classic-m1.synacor.tk;mid=2;] index - Resetting DB index data
2021-07-02 09:26:42,718 INFO  [ReIndex-0] [name=akshat@shashi-classic-m1.synacor.tk;mid=2;] index - Deleting index store data
2021-07-02 09:26:42,720 INFO  [ReIndex-0] [name=akshat@shashi-classic-m1.synacor.tk;mid=2;] index - Re-indexing all items
2021-07-02 09:26:42,986 INFO  [ReIndex-0] [name=akshat@shashi-classic-m1.synacor.tk;mid=2;] zimlet - Loaded class com.zimbra.cs.zimlet.handler.NANPHandler
2021-07-02 09:26:42,992 INFO  [ReIndex-0] [name=akshat@shashi-classic-m1.synacor.tk;mid=2;] zimlet - Loaded class com.zimbra.cs.zimlet.handler.RegexHandler
2021-07-02 09:26:43,206 WARN  [ReIndex-0] [name=akshat@shashi-classic-m1.synacor.tk;mid=2;] ParsedMessage - Unable to parse part=2 filename=sample-pdf-file.pdf content-type=application/pdf message-id=<229522532.122.1625216651106.JavaMail.zimbra@shashi-classic-m1.synacor.tk>
com.zimbra.cs.mime.MimeHandlerException: extraction failed
	at com.zimbra.cs.mime.handler.ConverterHandler.getContentImpl(ConverterHandler.java:122)
	at com.zimbra.cs.mime.MimeHandler.getContent(MimeHandler.java:180)
	at com.zimbra.cs.mime.ParsedMessage.analyzePart(ParsedMessage.java:1152)
	at com.zimbra.cs.mime.ParsedMessage.analyzeNonBodyParts(ParsedMessage.java:442)
	at com.zimbra.cs.mime.ParsedMessage.analyzeFully(ParsedMessage.java:473)
	at com.zimbra.cs.mailbox.Message.generateIndexData(Message.java:1405)
	at com.zimbra.cs.mailbox.MailboxIndex.indexItemList(MailboxIndex.java:774)
	at com.zimbra.cs.mailbox.MailboxIndex.indexDeferredItems(MailboxIndex.java:411)
	at com.zimbra.cs.mailbox.MailboxIndex.access$600(MailboxIndex.java:85)
	at com.zimbra.cs.mailbox.MailboxIndex$ReIndexTask.reIndex(MailboxIndex.java:587)
	at com.zimbra.cs.mailbox.MailboxIndex$ReIndexTask.exec(MailboxIndex.java:528)
	at com.zimbra.cs.mailbox.MailboxIndex$IndexTask.run(MailboxIndex.java:1418)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:830)
Caused by: org.apache.http.NoHttpResponseException: shashi-classic-m1.synacor.tk:7047 failed to respond
	at org.apache.http.impl.conn.DefaultHttpResponseParser.parseHead(DefaultHttpResponseParser.java:141)
	at org.apache.http.impl.conn.DefaultHttpResponseParser.parseHead(DefaultHttpResponseParser.java:56)
	at org.apache.http.impl.io.AbstractMessageParser.parse(AbstractMessageParser.java:259)
	at org.apache.http.impl.DefaultBHttpClientConnection.receiveResponseHeader(DefaultBHttpClientConnection.java:163)
	at org.apache.http.impl.conn.CPoolProxy.receiveResponseHeader(CPoolProxy.java:157)
	at org.apache.http.protocol.HttpRequestExecutor.doReceiveResponse(HttpRequestExecutor.java:273)
	at org.apache.http.protocol.HttpRequestExecutor.execute(HttpRequestExecutor.java:125)
	at org.apache.http.impl.execchain.MainClientExec.execute(MainClientExec.java:272)
	at org.apache.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:186)
	at org.apache.http.impl.execchain.RetryExec.execute(RetryExec.java:89)
	at org.apache.http.impl.execchain.RedirectExec.execute(RedirectExec.java:110)
	at org.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:185)
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:83)
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:108)
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:56)
	at com.zimbra.cs.convert.AbstractConverterClient.call(AbstractConverterClient.java:128)
	at com.zimbra.cs.convert.AbstractConverterClient.putOrPost(AbstractConverterClient.java:179)
	at com.zimbra.cs.convert.AbstractConverterClient.post(AbstractConverterClient.java:159)
	at com.zimbra.cs.convert.LegacyConverterClient.extract(LegacyConverterClient.java:38)
	at com.zimbra.cs.convert.PooledConverterClient.extract(PooledConverterClient.java:45)
	at com.zimbra.cs.mime.handler.ConverterHandler.getContentImpl(ConverterHandler.java:109)
	... 16 more
2021-07-02 09:26:43,209 WARN  [ReIndex-0] [name=akshat@shashi-classic-m1.synacor.tk;mid=2;] ParsedMessage - Message had analysis errors in 1 parts (Message-Id: <229522532.122.1625216651106.JavaMail.zimbra@shashi-classic-m1.synacor.tk>, Subject: Sample)
```

While in case of RHEL, it is able to do re-indexing and extraction properly:
```
2021-07-02 06:26:53,552 INFO  [ReIndex-0] [name=akshat@zqa-278.eng.zimbra.com;mid=3;] index - Re-index start
2021-07-02 06:26:53,564 INFO  [ReIndex-0] [name=akshat@zqa-278.eng.zimbra.com;mid=3;] index - Resetting DB index data
2021-07-02 06:26:53,583 INFO  [ReIndex-0] [name=akshat@zqa-278.eng.zimbra.com;mid=3;] index - Deleting index store data
2021-07-02 06:26:53,615 INFO  [ReIndex-0] [name=akshat@zqa-278.eng.zimbra.com;mid=3;] index - Re-indexing all items
2021-07-02 06:26:55,498 INFO  [ReIndex-0] [name=akshat@zqa-278.eng.zimbra.com;mid=3;] zimlet - Loaded class com.zimbra.cs.zimlet.handler.NANPHandler
2021-07-02 06:26:55,504 INFO  [ReIndex-0] [name=akshat@zqa-278.eng.zimbra.com;mid=3;] zimlet - Loaded class com.zimbra.cs.zimlet.handler.RegexHandler
```

When we use `attachment_extraction_client_class=com.zimbra.cs.convert.TikaExtractionClient`, in both platforms Ubuntu and RHEL re-ndexing and extraction are getting performed properly.

But, the attachment content of PDF and docx are not searchable. This issue is identical in both case when we are using tika-core. While other docs like Spreadsheet, txt, json attachment are searchable, while with the same contents of docx in txt file content becomes searchable.

**Related PRs:**
[zm-mailbox](https://github.com/Zimbra/zm-mailbox/pull/1160)