### PR TITLE
ZBUG-1948: Bumped the version of owasp-java-html-sanitizer

### DIFF
--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -293,7 +293,7 @@ sub stage_zimbra_store_lib($)
        cpy_file("build/dist/ant-1.7.0-ziputil-patched.jar",                         "$stage_base_dir/opt/zimbra/jetty_base/common/lib/ant-1.7.0-ziputil-patched.jar");
        cpy_file("build/dist/ical4j-0.9.16-patched.jar",                             "$stage_base_dir/opt/zimbra/jetty_base/common/lib/ical4j-0.9.16-patched.jar");
        cpy_file("build/dist/nekohtml-1.9.13.1z.jar",                                "$stage_base_dir/opt/zimbra/jetty_base/common/lib/nekohtml-1.9.13.1z.jar");
-       cpy_file("build/dist/owasp-java-html-sanitizer-20190610.2z.jar",             "$stage_base_dir/opt/zimbra/jetty_base/common/lib/owasp-java-html-sanitizer-20190610.2z.jar");
+       cpy_file("build/dist/owasp-java-html-sanitizer-20190610.3z.jar",             "$stage_base_dir/opt/zimbra/jetty_base/common/lib/owasp-java-html-sanitizer-20190610.3z.jar");
        cpy_file("build/dist/zmzimbratozimbramig-8.7.jar",                           "$stage_base_dir/opt/zimbra/lib/jars/zmzimbratozimbramig.jar");
        cpy_file("build/dist/jcharset-2.0.jar",                                      "$stage_base_dir/opt/zimbra/jetty_base/common/endorsed/jcharset.jar");
        cpy_file("build/dist/java-semver-0.9.0.jar",                                 "$stage_base_dir/opt/zimbra/jetty_base/common/lib/java-semver-0.9.0.jar");


### PR DESCRIPTION
Bumped the version of owasp-java-html-sanitizer


**Reference PRs:**
[zm-mailbox PR1](https://github.com/Zimbra/zm-mailbox/pull/1145)
[zm-mailbox PR2](https://github.com/Zimbra/zm-mailbox/pull/1172)
[owasp-java-html-sanitizer](https://github.com/Zimbra/java-html-sanitizer-release-20190610.1/pull/5)