### PR TITLE
ZCS-10728: pdf/doc/ppt/xls contents not searchable after switching from tika-app-1.24.1.jar to tika-core-1.24.1.jar

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -160,6 +160,8 @@
     <dependency org="org.apache.pdfbox" name="pdfbox" rev="2.0.24"/>
     <dependency org="org.apache.pdfbox" name="jempbox" rev="1.8.16"/>
     <dependency org="org.apache.pdfbox" name="fontbox" rev="2.0.24"/>
+    <dependency org="org.apache.commons" name="commons-math3" rev="3.6.1"/>
+    <dependency org="com.github.veithen.cosmos.bootstrap" name="org.tukaani.xz" rev="0.3"/>
     <dependency org="eu.bitwalker" name="UserAgentUtils" rev="1.21"/>
     <dependency org="org.apache.tika" name="tika-core" rev="1.24.1"/>
     <dependency org="org.apache.poi" name="poi-ooxml" rev="4.1.2"/>

--- a/ivy.xml
+++ b/ivy.xml
@@ -161,7 +161,7 @@
     <dependency org="org.apache.pdfbox" name="jempbox" rev="1.8.16"/>
     <dependency org="org.apache.pdfbox" name="fontbox" rev="2.0.24"/>
     <dependency org="org.apache.commons" name="commons-math3" rev="3.6.1"/>
-    <dependency org="com.github.veithen.cosmos.bootstrap" name="org.tukaani.xz" rev="0.3"/>
+    <dependency org="org.tukaani" name="xz" rev="1.9"/>
     <dependency org="eu.bitwalker" name="UserAgentUtils" rev="1.21"/>
     <dependency org="org.apache.tika" name="tika-core" rev="1.24.1"/>
     <dependency org="org.apache.poi" name="poi-ooxml" rev="4.1.2"/>

--- a/ivy.xml
+++ b/ivy.xml
@@ -156,6 +156,10 @@
     <dependency org="org.apache.xmlgraphics" name="batik-i18n" rev="1.9"/>
     <dependency org="org.apache.xmlgraphics" name="batik-util" rev="1.8"/>
     <dependency org="org.apache.tika" name="tika-app" rev="1.24.1"/>
+    <dependency org="org.apache.tika" name="tika-parsers" rev="1.24.1"/>
+    <dependency org="org.apache.pdfbox" name="pdfbox" rev="2.0.24"/>
+    <dependency org="org.apache.pdfbox" name="jempbox" rev="1.8.16"/>
+    <dependency org="org.apache.pdfbox" name="fontbox" rev="2.0.24"/>
     <dependency org="eu.bitwalker" name="UserAgentUtils" rev="1.21"/>
     <dependency org="org.apache.tika" name="tika-core" rev="1.24.1"/>
     <dependency org="org.apache.poi" name="poi-ooxml" rev="4.1.2"/>

--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -195,8 +195,8 @@ sub stage_zimbra_core_lib($)
         cpy_file("build/dist/batik-util-1.8.jar",                                   "$stage_base_dir/opt/zimbra/lib/jars/batik-util-1.8.jar");
         cpy_file("build/dist/sac-1.3.jar",                                          "$stage_base_dir/opt/zimbra/lib/jars/sac-1.3.jar");
         cpy_file("build/dist/policy-2.3.jar",                                       "$stage_base_dir/opt/zimbra/lib/jars/policy-2.3.jar");
-        cpy_file("build/dist/slf4j-api-1.7.30.jar",                                  "$stage_base_dir/opt/zimbra/lib/jars/slf4j-api-1.7.30.jar");
-        cpy_file("build/dist/slf4j-log4j12-1.7.30.jar",                              "$stage_base_dir/opt/zimbra/lib/jars/slf4j-log4j12-1.7.30.jar");
+        cpy_file("build/dist/slf4j-api-1.7.30.jar",                                 "$stage_base_dir/opt/zimbra/lib/jars/slf4j-api-1.7.30.jar");
+        cpy_file("build/dist/slf4j-log4j12-1.7.30.jar",                             "$stage_base_dir/opt/zimbra/lib/jars/slf4j-log4j12-1.7.30.jar");
         cpy_file("build/dist/spring-aop-5.1.10.RELEASE.jar",                        "$stage_base_dir/opt/zimbra/lib/jars/spring-aop-5.1.10.RELEASE.jar");
         cpy_file("build/dist/spring-beans-5.1.10.RELEASE.jar",                      "$stage_base_dir/opt/zimbra/lib/jars/spring-beans-5.1.10.RELEASE.jar");
         cpy_file("build/dist/spring-context-5.1.10.RELEASE.jar",                    "$stage_base_dir/opt/zimbra/lib/jars/spring-context-5.1.10.RELEASE.jar");
@@ -314,6 +314,9 @@ sub stage_zimbra_store_lib($)
        cpy_file("build/dist/pdfbox-2.0.24.jar",                                     "$stage_base_dir/opt/zimbra/jetty_base/common/lib/pdfbox-2.0.24.jar");
        cpy_file("build/dist/jempbox-1.8.16.jar",                                    "$stage_base_dir/opt/zimbra/jetty_base/common/lib/jempbox-1.8.16.jar");
        cpy_file("build/dist/fontbox-2.0.24.jar",                                    "$stage_base_dir/opt/zimbra/jetty_base/common/lib/fontbox-2.0.24.jar");
+       cpy_file("build/dist/commons-math3-3.6.1.jar",                               "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-math3-3.6.1.jar");
+       cpy_file("build/dist/commons-csv-1.2.jar",                                   "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-csv-1.2.jar");
+       cpy_file("build/dist/xz-1.8.jar",                                            "$stage_base_dir/opt/zimbra/jetty_base/common/lib/xz-1.8.jar");
        cpy_file("build/dist/saaj-impl-1.5.1.jar",                                   "$stage_base_dir/opt/zimbra/lib/ext-common/saaj-impl-1.5.1.jar");
        cpy_file("build/dist/antisamy-1.5.8z.jar",                                   "$stage_base_dir/opt/zimbra/jetty_base/webapps/service/WEB-INF/lib/antisamy-1.5.8z.jar");
        cpy_file("build/dist/UserAgentUtils-1.21.jar",                               "$stage_base_dir/opt/zimbra/jetty_base/common/lib/UserAgentUtils-1.21.jar");

--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -310,6 +310,10 @@ sub stage_zimbra_store_lib($)
        cpy_file("build/dist/jaxb-api-2.3.1.jar",                                    "$stage_base_dir/opt/zimbra/jetty_base/common/lib/jaxb-api-2.3.1.jar");
        cpy_file("build/dist/jaxws-api-2.3.1.jar",                                   "$stage_base_dir/opt/zimbra/jetty_base/common/lib/jaxws-api-2.3.1.jar");
        cpy_file("build/dist/tika-core-1.24.1.jar",                                  "$stage_base_dir/opt/zimbra/jetty_base/common/lib/tika-core-1.24.1.jar");
+       cpy_file("build/dist/tika-parsers-1.24.1.jar",                               "$stage_base_dir/opt/zimbra/jetty_base/common/lib/tika-parsers-1.24.1.jar");
+       cpy_file("build/dist/pdfbox-2.0.24.jar",                                     "$stage_base_dir/opt/zimbra/jetty_base/common/lib/pdfbox-2.0.24.jar");
+       cpy_file("build/dist/jempbox-1.8.16.jar",                                    "$stage_base_dir/opt/zimbra/jetty_base/common/lib/jempbox-1.8.16.jar");
+       cpy_file("build/dist/fontbox-2.0.24.jar",                                    "$stage_base_dir/opt/zimbra/jetty_base/common/lib/fontbox-2.0.24.jar");
        cpy_file("build/dist/saaj-impl-1.5.1.jar",                                   "$stage_base_dir/opt/zimbra/lib/ext-common/saaj-impl-1.5.1.jar");
        cpy_file("build/dist/antisamy-1.5.8z.jar",                                   "$stage_base_dir/opt/zimbra/jetty_base/webapps/service/WEB-INF/lib/antisamy-1.5.8z.jar");
        cpy_file("build/dist/UserAgentUtils-1.21.jar",                               "$stage_base_dir/opt/zimbra/jetty_base/common/lib/UserAgentUtils-1.21.jar");

--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -316,7 +316,7 @@ sub stage_zimbra_store_lib($)
        cpy_file("build/dist/fontbox-2.0.24.jar",                                    "$stage_base_dir/opt/zimbra/jetty_base/common/lib/fontbox-2.0.24.jar");
        cpy_file("build/dist/commons-math3-3.6.1.jar",                               "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-math3-3.6.1.jar");
        cpy_file("build/dist/commons-csv-1.2.jar",                                   "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-csv-1.2.jar");
-       cpy_file("build/dist/xz-1.8.jar",                                            "$stage_base_dir/opt/zimbra/jetty_base/common/lib/xz-1.8.jar");
+       cpy_file("build/dist/xz-1.9.jar",                                            "$stage_base_dir/opt/zimbra/jetty_base/common/lib/xz-1.9.jar");
        cpy_file("build/dist/saaj-impl-1.5.1.jar",                                   "$stage_base_dir/opt/zimbra/lib/ext-common/saaj-impl-1.5.1.jar");
        cpy_file("build/dist/antisamy-1.5.8z.jar",                                   "$stage_base_dir/opt/zimbra/jetty_base/webapps/service/WEB-INF/lib/antisamy-1.5.8z.jar");
        cpy_file("build/dist/UserAgentUtils-1.21.jar",                               "$stage_base_dir/opt/zimbra/jetty_base/common/lib/UserAgentUtils-1.21.jar");


### PR DESCRIPTION
**Problem:**
pdf/doc/docx contents not searchable after switching from tika-app-1.24.1.jar to tika-core-1.24.1.jar

**Fix:**
Added jars which are necessary for the parsing and extraction of the documents which were not working after replacing `tika-app` jar to the `tika-core` jar. Now after adding these required jars like tika-parser and it's dependent jars the content of the search in the e-mail for the documents like `pdf, doc, docx, ppt, pptx, xls, xlsx`.

**Testing Done:**
- Verified on Ubuntu18 build contents of the attachment in e-mail for the above mentioned documents are searchable now.
- Verified on RHEL8 build contents of the attachment in e-mail for the above mentioned documents are searchable now.

**Related PRs:**
[zm-mailbox](https://github.com/Zimbra/zm-mailbox/pull/1173)

**Dependent PRs:**
[zm-mailbox](https://github.com/Zimbra/zm-mailbox/pull/1160)
[zm-zcs-lib](https://github.com/Zimbra/zm-zcs-lib/pull/80)