### PR TITLE
ZCS-10766: Briefcase contents not searchable

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -160,6 +160,9 @@
     <dependency org="org.apache.pdfbox" name="pdfbox" rev="2.0.24"/>
     <dependency org="org.apache.pdfbox" name="jempbox" rev="1.8.16"/>
     <dependency org="org.apache.pdfbox" name="fontbox" rev="2.0.24"/>
+    <dependency org="org.apache.commons" name="commons-math3" rev="3.6.1"/>
+    <dependency org="org.apache.commons" name="commons-csv" rev="1.8"/>
+    <dependency org="com.github.veithen.cosmos.bootstrap" name="org.tukaani.xz" rev="0.3"/>
     <dependency org="eu.bitwalker" name="UserAgentUtils" rev="1.21"/>
     <dependency org="org.apache.tika" name="tika-core" rev="1.24.1"/>
     <dependency org="org.apache.poi" name="poi-ooxml" rev="4.1.2"/>

--- a/ivy.xml
+++ b/ivy.xml
@@ -164,6 +164,8 @@
     <dependency org="org.apache.commons" name="commons-csv" rev="1.8"/>
     <dependency org="com.github.veithen.cosmos.bootstrap" name="org.tukaani.xz" rev="0.3"/>
     <dependency org="eu.bitwalker" name="UserAgentUtils" rev="1.21"/>
+    <dependency org="com.drewnoakes" name="metadata-extractor" rev="2.16.0"/>
+    <dependency org="com.adobe.xmp" name="xmpcore" rev="6.1.11"/>
     <dependency org="org.apache.tika" name="tika-core" rev="1.24.1"/>
     <dependency org="org.apache.poi" name="poi-ooxml" rev="4.1.2"/>
     <dependency org="org.apache.poi" name="poi-ooxml-schemas" rev="4.1.2"/>

--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -195,8 +195,8 @@ sub stage_zimbra_core_lib($)
         cpy_file("build/dist/batik-util-1.8.jar",                                   "$stage_base_dir/opt/zimbra/lib/jars/batik-util-1.8.jar");
         cpy_file("build/dist/sac-1.3.jar",                                          "$stage_base_dir/opt/zimbra/lib/jars/sac-1.3.jar");
         cpy_file("build/dist/policy-2.3.jar",                                       "$stage_base_dir/opt/zimbra/lib/jars/policy-2.3.jar");
-        cpy_file("build/dist/slf4j-api-1.7.30.jar",                                  "$stage_base_dir/opt/zimbra/lib/jars/slf4j-api-1.7.30.jar");
-        cpy_file("build/dist/slf4j-log4j12-1.7.30.jar",                              "$stage_base_dir/opt/zimbra/lib/jars/slf4j-log4j12-1.7.30.jar");
+        cpy_file("build/dist/slf4j-api-1.7.30.jar",                                 "$stage_base_dir/opt/zimbra/lib/jars/slf4j-api-1.7.30.jar");
+        cpy_file("build/dist/slf4j-log4j12-1.7.30.jar",                             "$stage_base_dir/opt/zimbra/lib/jars/slf4j-log4j12-1.7.30.jar");
         cpy_file("build/dist/spring-aop-5.1.10.RELEASE.jar",                        "$stage_base_dir/opt/zimbra/lib/jars/spring-aop-5.1.10.RELEASE.jar");
         cpy_file("build/dist/spring-beans-5.1.10.RELEASE.jar",                      "$stage_base_dir/opt/zimbra/lib/jars/spring-beans-5.1.10.RELEASE.jar");
         cpy_file("build/dist/spring-context-5.1.10.RELEASE.jar",                    "$stage_base_dir/opt/zimbra/lib/jars/spring-context-5.1.10.RELEASE.jar");
@@ -314,6 +314,9 @@ sub stage_zimbra_store_lib($)
        cpy_file("build/dist/pdfbox-2.0.24.jar",                                     "$stage_base_dir/opt/zimbra/jetty_base/common/lib/pdfbox-2.0.24.jar");
        cpy_file("build/dist/jempbox-1.8.16.jar",                                    "$stage_base_dir/opt/zimbra/jetty_base/common/lib/jempbox-1.8.16.jar");
        cpy_file("build/dist/fontbox-2.0.24.jar",                                    "$stage_base_dir/opt/zimbra/jetty_base/common/lib/fontbox-2.0.24.jar");
+       cpy_file("build/dist/commons-math3-3.6.1.jar",                               "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-math3-3.6.1.jar");
+       cpy_file("build/dist/commons-csv-1.8.jar",                                   "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-csv-1.8.jar");
+       cpy_file("build/dist/xz-1.8.jar",                                            "$stage_base_dir/opt/zimbra/jetty_base/common/lib/xz-1.8.jar");
        cpy_file("build/dist/saaj-impl-1.5.1.jar",                                   "$stage_base_dir/opt/zimbra/lib/ext-common/saaj-impl-1.5.1.jar");
        cpy_file("build/dist/antisamy-1.5.8z.jar",                                   "$stage_base_dir/opt/zimbra/jetty_base/webapps/service/WEB-INF/lib/antisamy-1.5.8z.jar");
        cpy_file("build/dist/UserAgentUtils-1.21.jar",                               "$stage_base_dir/opt/zimbra/jetty_base/common/lib/UserAgentUtils-1.21.jar");

--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -317,6 +317,8 @@ sub stage_zimbra_store_lib($)
        cpy_file("build/dist/commons-math3-3.6.1.jar",                               "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-math3-3.6.1.jar");
        cpy_file("build/dist/commons-csv-1.8.jar",                                   "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-csv-1.8.jar");
        cpy_file("build/dist/xz-1.8.jar",                                            "$stage_base_dir/opt/zimbra/jetty_base/common/lib/xz-1.8.jar");
+       cpy_file("build/dist/metadata-extractor-2.16.0.jar",                         "$stage_base_dir/opt/zimbra/jetty_base/common/lib/metadata-extractor-2.16.0.jar");
+       cpy_file("build/dist/xmpcore-6.1.11.jar",                                    "$stage_base_dir/opt/zimbra/jetty_base/common/lib/xmpcore-6.1.11.jar");
        cpy_file("build/dist/saaj-impl-1.5.1.jar",                                   "$stage_base_dir/opt/zimbra/lib/ext-common/saaj-impl-1.5.1.jar");
        cpy_file("build/dist/antisamy-1.5.8z.jar",                                   "$stage_base_dir/opt/zimbra/jetty_base/webapps/service/WEB-INF/lib/antisamy-1.5.8z.jar");
        cpy_file("build/dist/UserAgentUtils-1.21.jar",                               "$stage_base_dir/opt/zimbra/jetty_base/common/lib/UserAgentUtils-1.21.jar");


### PR DESCRIPTION
**Problem:**
Briefcase uploads were not searchable

**Fix:**
While working on this found that while trying to create or edit the presentation following exception were getting observed:
- `java.lang.NoClassDefFoundError: Could not initialize class com.drew.imaging.jpeg.JpegMetadataReader`
- `java.lang.NoClassDefFoundError: com/adobe/internal/xmp/XMPException`

To fix these issues added the following dependencies to create and edit pptx presentation while using `TikaExtractorClient`:
- `metadata-extractor-2.16.0.jar`
- `xmpcore-6.1.11.jar`

**Testing Done:**
- Now, search is working in Briefcase.
- Verified now able to create and edit a presentation.

**Related PRs:**
[zm-mailbox](https://github.com/Zimbra/zm-mailbox/pull/1174)

**Dependent PRs:**
- ZCS-10598: [zm-mailbox](https://github.com/Zimbra/zm-mailbox/pull/1160)
- ZCS-10598: [zm-zcs-lib](https://github.com/Zimbra/zm-zcs-lib/pull/80)
- ZCS-10728: [zm-mailbox](https://github.com/Zimbra/zm-mailbox/pull/1173)
- ZCS-10728: [zm-zcs-lib](https://github.com/Zimbra/zm-zcs-lib/pull/82)