### PR TITLE
ZCS-11132: back port changes of Tika extraction to 8.8.15 from 9.0.0

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -36,7 +36,7 @@
     <dependency org="commons-collections" name="commons-collections" rev="3.2.2"/>
     <dependency org="commons-dbcp" name="commons-dbcp" rev="1.4"/>
     <dependency org="commons-fileupload" name="commons-fileupload" rev="1.2.2"/>
-    <dependency org="commons-io" name="commons-io" rev="1.4"/>
+    <dependency org="commons-io" name="commons-io" rev="2.6"/>
     <dependency org="commons-lang" name="commons-lang" rev="2.6"/>
     <dependency org="commons-logging" name="commons-logging" rev="1.1.1"/>
     <dependency org="commons-net" name="commons-net" rev="3.3"/>
@@ -157,6 +157,7 @@
     <dependency org="org.w3c.css" name="sac" rev="1.3"/>
     <dependency org="org.apache.xmlgraphics" name="batik-i18n" rev="1.9"/>
     <dependency org="org.apache.xmlgraphics" name="batik-util" rev="1.8"/>
+    <dependency org="org.apache.tika" name="tika-app" rev="1.24.1"/>
     <exclude org="com.noelios.restlet" module="com.noelios.restlet"/>
     <exclude org="javax.sql" module="jdbc-stdext"/>
     <exclude org="javax.transaction" module="jta"/>


### PR DESCRIPTION
Backporting Tika extraction client changes to 8.8.15 from 9.0.0