### PR TITLE
Bugfix/zcs 11132 1

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -36,7 +36,7 @@
     <dependency org="commons-collections" name="commons-collections" rev="3.2.2"/>
     <dependency org="commons-dbcp" name="commons-dbcp" rev="1.4"/>
     <dependency org="commons-fileupload" name="commons-fileupload" rev="1.2.2"/>
-    <dependency org="commons-io" name="commons-io" rev="1.4"/>
+    <dependency org="commons-io" name="commons-io" rev="2.6"/>
     <dependency org="commons-lang" name="commons-lang" rev="2.6"/>
     <dependency org="commons-logging" name="commons-logging" rev="1.1.1"/>
     <dependency org="commons-net" name="commons-net" rev="3.3"/>
@@ -63,7 +63,7 @@
     <dependency org="net.spy" name="spymemcached" rev="2.12.1" transitive="false"/>
     <dependency org="oauth" name="oauth" rev="1.4"/>
     <dependency org="org.antlr" name="antlr" rev="3.2"/>
-    <dependency org="org.apache.commons" name="commons-compress" rev="1.10"/>
+    <dependency org="org.apache.commons" name="commons-compress" rev="1.20"/>
     <dependency org="org.apache.commons" name="commons-csv" rev="1.2"/>
     <dependency org="org.apache.commons" name="commons-pool2" rev="2.4.2"/>
     <dependency org="org.apache.curator" name="curator-client" rev="2.0.1-incubating"/>

--- a/ivy.xml
+++ b/ivy.xml
@@ -5,10 +5,10 @@
   <dependencies>
     <dependency org="ant" name="ant" rev="1.6.5"/>
     <dependency org="ant-contrib" name="ant-contrib" rev="1.0b2"/>
-    <dependency org="asm" name="asm" rev="3.3.1"/>
     <dependency org="org.apache.sshd" name="sshd-common" rev="2.6.1"/>
     <dependency org="org.apache.sshd" name="sshd-core" rev="2.6.1"/>
     <dependency org="net.i2p.crypto" name="eddsa" rev="0.3.0"/>
+    <dependency org="org.ow2.asm" name="asm" rev="8.0.1"/>
     <dependency org="com.101tec" name="zkclient" rev="0.1.0"/>
     <dependency org="com.github.stephenc" name="jamm" rev="0.2.5"/>
     <dependency org="com.google.guava" name="guava" rev="23.0"/>
@@ -32,7 +32,7 @@
     <dependency org="com.unboundid" name="unboundid-ldapsdk" rev="2.3.5"/>
     <dependency org="com.yahoo.platform.yui" name="yuicompressor" rev="2.4.2-zimbra"/>
     <dependency org="commons-cli" name="commons-cli" rev="1.2"/>
-    <dependency org="commons-codec" name="commons-codec" rev="1.7"/>
+    <dependency org="commons-codec" name="commons-codec" rev="1.14"/>
     <dependency org="commons-collections" name="commons-collections" rev="3.2.2"/>
     <dependency org="commons-dbcp" name="commons-dbcp" rev="1.4"/>
     <dependency org="commons-fileupload" name="commons-fileupload" rev="1.2.2"/>
@@ -157,6 +157,7 @@
     <dependency org="org.w3c.css" name="sac" rev="1.3"/>
     <dependency org="org.apache.xmlgraphics" name="batik-i18n" rev="1.9"/>
     <dependency org="org.apache.xmlgraphics" name="batik-util" rev="1.8"/>
+    <dependency org="org.apache.tika" name="tika-app" rev="1.24.1"/>
     <exclude org="com.noelios.restlet" module="com.noelios.restlet"/>
     <exclude org="javax.sql" module="jdbc-stdext"/>
     <exclude org="javax.transaction" module="jta"/>

--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -109,10 +109,10 @@ sub stage_zimbra_core_lib($)
         cpy_file("build/dist/antlr-3.2.jar",                                        "$stage_base_dir/opt/zimbra/lib/jars/antlr-3.2.jar");
         cpy_file("build/dist/apache-jsieve-core-0.5.jar",                           "$stage_base_dir/opt/zimbra/lib/jars/apache-jsieve-core-0.5.jar");
         cpy_file("build/dist/apache-log4j-extras-1.0.jar",                          "$stage_base_dir/opt/zimbra/lib/jars/apache-log4j-extras-1.0.jar");
-        cpy_file("build/dist/asm-3.3.1.jar",                                        "$stage_base_dir/opt/zimbra/lib/jars/asm-3.3.1.jar");
-        cpy_file("build/dist/bcprov-jdk15on-1.55.jar",                              "$stage_base_dir/opt/zimbra/lib/jars/bcprov-jdk15on-1.55.jar");
+        cpy_file("build/dist/asm-8.0.1.jar",                                        "$stage_base_dir/opt/zimbra/lib/jars/asm-8.0.1.jar");
+        cpy_file("build/dist/bcprov-jdk15on-1.64.jar",                              "$stage_base_dir/opt/zimbra/lib/jars/bcprov-jdk15on-1.64.jar");
         cpy_file("build/dist/commons-cli-1.2.jar",                                  "$stage_base_dir/opt/zimbra/lib/jars/commons-cli-1.2.jar");
-        cpy_file("build/dist/commons-codec-1.7.jar",                                "$stage_base_dir/opt/zimbra/lib/jars/commons-codec-1.7.jar");
+        cpy_file("build/dist/commons-codec-1.14.jar",                               "$stage_base_dir/opt/zimbra/lib/jars/commons-codec-1.14.jar");
         cpy_file("build/dist/commons-collections-3.2.2.jar",                        "$stage_base_dir/opt/zimbra/lib/jars/commons-collections-3.2.2.jar");
         cpy_file("build/dist/commons-compress-1.20.jar",                            "$stage_base_dir/opt/zimbra/lib/jars/commons-compress-1.20.jar");
         cpy_file("build/dist/commons-csv-1.2.jar",                                  "$stage_base_dir/opt/zimbra/lib/jars/commons-csv-1.2.jar");
@@ -250,7 +250,7 @@ sub stage_zimbra_store_lib($)
        cpy_file("build/dist/apache-log4j-extras-1.0.jar",                           "$stage_base_dir/opt/zimbra/jetty_base/common/lib/apache-log4j-extras-1.0.jar");
        cpy_file("build/dist/bcprov-jdk15on-1.55.jar",                               "$stage_base_dir/opt/zimbra/jetty_base/common/lib/bcprov-jdk15on-1.55.jar");
        cpy_file("build/dist/commons-cli-1.2.jar",                                   "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-cli-1.2.jar");
-       cpy_file("build/dist/commons-codec-1.7.jar",                                 "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-codec-1.7.jar");
+       cpy_file("build/dist/commons-codec-1.14.jar",                                "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-codec-1.14.jar");
        cpy_file("build/dist/commons-collections-3.2.2.jar",                         "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-collections-3.2.2.jar");
        cpy_file("build/dist/commons-compress-1.20.jar",                             "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-compress-1.20.jar");
        cpy_file("build/dist/commons-dbcp-1.4.jar",                                  "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-dbcp-1.4.jar");

--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -110,7 +110,7 @@ sub stage_zimbra_core_lib($)
         cpy_file("build/dist/apache-jsieve-core-0.5.jar",                           "$stage_base_dir/opt/zimbra/lib/jars/apache-jsieve-core-0.5.jar");
         cpy_file("build/dist/apache-log4j-extras-1.0.jar",                          "$stage_base_dir/opt/zimbra/lib/jars/apache-log4j-extras-1.0.jar");
         cpy_file("build/dist/asm-8.0.1.jar",                                        "$stage_base_dir/opt/zimbra/lib/jars/asm-8.0.1.jar");
-        cpy_file("build/dist/bcprov-jdk15on-1.64.jar",                              "$stage_base_dir/opt/zimbra/lib/jars/bcprov-jdk15on-1.64.jar");
+        cpy_file("build/dist/bcprov-jdk15on-1.55.jar",                              "$stage_base_dir/opt/zimbra/lib/jars/bcprov-jdk15on-1.55.jar");
         cpy_file("build/dist/commons-cli-1.2.jar",                                  "$stage_base_dir/opt/zimbra/lib/jars/commons-cli-1.2.jar");
         cpy_file("build/dist/commons-codec-1.14.jar",                               "$stage_base_dir/opt/zimbra/lib/jars/commons-codec-1.14.jar");
         cpy_file("build/dist/commons-collections-3.2.2.jar",                        "$stage_base_dir/opt/zimbra/lib/jars/commons-collections-3.2.2.jar");

--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -114,11 +114,11 @@ sub stage_zimbra_core_lib($)
         cpy_file("build/dist/commons-cli-1.2.jar",                                  "$stage_base_dir/opt/zimbra/lib/jars/commons-cli-1.2.jar");
         cpy_file("build/dist/commons-codec-1.7.jar",                                "$stage_base_dir/opt/zimbra/lib/jars/commons-codec-1.7.jar");
         cpy_file("build/dist/commons-collections-3.2.2.jar",                        "$stage_base_dir/opt/zimbra/lib/jars/commons-collections-3.2.2.jar");
-        cpy_file("build/dist/commons-compress-1.10.jar",                            "$stage_base_dir/opt/zimbra/lib/jars/commons-compress-1.10.jar");
+        cpy_file("build/dist/commons-compress-1.20.jar",                            "$stage_base_dir/opt/zimbra/lib/jars/commons-compress-1.20.jar");
         cpy_file("build/dist/commons-csv-1.2.jar",                                  "$stage_base_dir/opt/zimbra/lib/jars/commons-csv-1.2.jar");
         cpy_file("build/dist/commons-dbcp-1.4.jar",                                 "$stage_base_dir/opt/zimbra/lib/jars/commons-dbcp-1.4.jar");
         cpy_file("build/dist/commons-fileupload-1.2.2.jar",                         "$stage_base_dir/opt/zimbra/lib/jars/commons-fileupload-1.2.2.jar");
-        cpy_file("build/dist/commons-io-1.4.jar",                                   "$stage_base_dir/opt/zimbra/lib/jars/commons-io-1.4.jar");
+        cpy_file("build/dist/commons-io-2.6.jar",                                   "$stage_base_dir/opt/zimbra/lib/jars/commons-io-2.6.jar");
         cpy_file("build/dist/commons-lang-2.6.jar",                                 "$stage_base_dir/opt/zimbra/lib/jars/commons-lang-2.6.jar");
         cpy_file("build/dist/commons-net-3.3.jar",                                  "$stage_base_dir/opt/zimbra/lib/jars/commons-net-3.3.jar");
         cpy_file("build/dist/commons-pool-1.6.jar",                                 "$stage_base_dir/opt/zimbra/lib/jars/commons-pool-1.6.jar");
@@ -252,10 +252,10 @@ sub stage_zimbra_store_lib($)
        cpy_file("build/dist/commons-cli-1.2.jar",                                   "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-cli-1.2.jar");
        cpy_file("build/dist/commons-codec-1.7.jar",                                 "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-codec-1.7.jar");
        cpy_file("build/dist/commons-collections-3.2.2.jar",                         "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-collections-3.2.2.jar");
-       cpy_file("build/dist/commons-compress-1.10.jar",                             "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-compress-1.10.jar");
+       cpy_file("build/dist/commons-compress-1.20.jar",                             "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-compress-1.20.jar");
        cpy_file("build/dist/commons-dbcp-1.4.jar",                                  "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-dbcp-1.4.jar");
        cpy_file("build/dist/commons-fileupload-1.2.2.jar",                          "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-fileupload-1.2.2.jar");
-       cpy_file("build/dist/commons-io-1.4.jar",                                    "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-io-1.4.jar");
+       cpy_file("build/dist/commons-io-2.6.jar",                                    "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-io-2.6.jar");
        cpy_file("build/dist/commons-lang-2.6.jar",                                  "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-lang-2.6.jar");
        cpy_file("build/dist/commons-logging-1.1.1.jar",                             "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-logging-1.1.1.jar");
        cpy_file("build/dist/commons-net-3.3.jar",                                   "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-net-3.3.jar");


### PR DESCRIPTION
Back porting Tika extraction client changes from 9.0.0 to 8.8.15

https://github.com/Zimbra/zm-convertd-store/pull/17
https://github.com/Zimbra/zm-mailbox/pull/1224
https://github.com/Zimbra/zm-build/pull/200