### PR TITLE
update zm-ews-stub jar version

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -131,7 +131,7 @@
     <dependency org="redis.clients" name="jedis" rev="2.9.0"/>
     <dependency org="wsdl4j" name="wsdl4j" rev="1.6.3"/>
     <dependency org="xerces" name="xercesImpl" rev="2.9.1-patch-01"/>
-    <dependency org="zimbra" name="zm-ews-stub" rev="2.0"/>
+    <dependency org="zimbra" name="zm-ews-stub" rev="3.0"/>
     <dependency org="com.google.javascript" name="closure-compiler" rev="v20180204"/>
     <dependency org="com.github.zafarkhaja" name="java-semver" rev="0.9.0"/>
     <dependency org="io.jsonwebtoken" name="jjwt" rev="0.7.0" />

--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -218,7 +218,7 @@ sub stage_zimbra_core_lib($)
         cpy_file("build/dist/yuicompressor-2.4.2-zimbra.jar",                       "$stage_base_dir/opt/zimbra/lib/jars/yuicompressor-2.4.2-zimbra.jar");
         cpy_file("build/dist/zkclient-0.1.0.jar",                                   "$stage_base_dir/opt/zimbra/lib/jars/zkclient-0.1.0.jar");
         cpy_file("build/dist/zookeeper-3.4.5.jar",                                  "$stage_base_dir/opt/zimbra/lib/jars/zookeeper-3.4.5.jar");
-        cpy_file("build/dist/zm-ews-stub-2.0.jar",                                  "$stage_base_dir/opt/zimbra/lib/jars/zm-ews-stub-2.0.jar");
+        cpy_file("build/dist/zm-ews-stub-3.0.jar",                                  "$stage_base_dir/opt/zimbra/lib/jars/zm-ews-stub-3.0.jar");
         cpy_file("build/dist/ehcache-3.1.2.jar",                                    "$stage_base_dir/opt/zimbra/lib/jars/ehcache-3.1.2.jar");
         cpy_file("build/dist/zimbra-charset.jar",                                   "$stage_base_dir/opt/zimbra/lib/jars/zimbra-charset.jar");
         cpy_file("build/dist/ant-1.6.5.jar",                                        "$stage_base_dir/opt/zimbra/lib/jars/ant-1.6.5.jar");


### PR DESCRIPTION
Updated zm-zcs-lib ivy.xml and pkg-builder.pl, changed zm-ews-stub jar revision from 2.0 to 3.0.
This change is necessary as whenever we make changes in zm-ews-stub library we have to updated it's revision.

This changes shall be reviewed with old changes for zcs-4452
-  https://github.com/Zimbra/zm-ews-stub/pull/5/commits/0eebbd143212c83bca8d3e888d7e73c211f71c86
- https://github.com/Zimbra/zm-ews-store/pull/40/commits/6b14ad3e9d594d041900500d1a929d474d0f6e45
