### PR TITLE
ZBUG-1932: Upgrading owasp-java-html-sanitizer version

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -153,8 +153,8 @@
     <dependency org="javax.annotation" name="javax.annotation-api" rev="1.2"/>
     <dependency org="org.apache.xmlgraphics" name="batik-css" rev="1.7"/>
     <dependency org="org.w3c.css" name="sac" rev="1.3"/>
-    <dependency org="org.apache.xmlgraphics" name="batik-i18n" rev="1.9"/>
-    <dependency org="org.apache.xmlgraphics" name="batik-util" rev="1.8"/>
+    <dependency org="org.apache.xmlgraphics" name="batik-i18n" rev="1.14"/>
+    <dependency org="org.apache.xmlgraphics" name="batik-util" rev="1.14"/>
     <dependency org="org.apache.tika" name="tika-app" rev="1.24.1"/>
     <dependency org="org.apache.tika" name="tika-parsers" rev="1.24.1"/>
     <dependency org="org.apache.pdfbox" name="pdfbox" rev="2.0.24"/>

--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -191,8 +191,8 @@ sub stage_zimbra_core_lib($)
         cpy_file("build/dist/oauth-20100527.jar",                                   "$stage_base_dir/opt/zimbra/lib/jars/oauth-20100527.jar");
         cpy_file("build/dist/antisamy-1.5.8z2.jar",                                  "$stage_base_dir/opt/zimbra/lib/jars/antisamy-1.5.8z2.jar");
         cpy_file("build/dist/batik-css-1.7.jar",                                    "$stage_base_dir/opt/zimbra/lib/jars/batik-css-1.7.jar");
-        cpy_file("build/dist/batik-i18n-1.9.jar",                                   "$stage_base_dir/opt/zimbra/lib/jars/batik-i18n-1.9.jar");
-        cpy_file("build/dist/batik-util-1.8.jar",                                   "$stage_base_dir/opt/zimbra/lib/jars/batik-util-1.8.jar");
+        cpy_file("build/dist/batik-i18n-1.14.jar",                                  "$stage_base_dir/opt/zimbra/lib/jars/batik-i18n-1.14.jar");
+        cpy_file("build/dist/batik-util-1.14.jar",                                  "$stage_base_dir/opt/zimbra/lib/jars/batik-util-1.14.jar");
         cpy_file("build/dist/sac-1.3.jar",                                          "$stage_base_dir/opt/zimbra/lib/jars/sac-1.3.jar");
         cpy_file("build/dist/policy-2.3.jar",                                       "$stage_base_dir/opt/zimbra/lib/jars/policy-2.3.jar");
         cpy_file("build/dist/slf4j-api-1.7.30.jar",                                 "$stage_base_dir/opt/zimbra/lib/jars/slf4j-api-1.7.30.jar");
@@ -293,7 +293,7 @@ sub stage_zimbra_store_lib($)
        cpy_file("build/dist/ant-1.7.0-ziputil-patched.jar",                         "$stage_base_dir/opt/zimbra/jetty_base/common/lib/ant-1.7.0-ziputil-patched.jar");
        cpy_file("build/dist/ical4j-0.9.16-patched.jar",                             "$stage_base_dir/opt/zimbra/jetty_base/common/lib/ical4j-0.9.16-patched.jar");
        cpy_file("build/dist/nekohtml-1.9.13.1z.jar",                                "$stage_base_dir/opt/zimbra/jetty_base/common/lib/nekohtml-1.9.13.1z.jar");
-       cpy_file("build/dist/owasp-java-html-sanitizer-20190610.3z.jar",             "$stage_base_dir/opt/zimbra/jetty_base/common/lib/owasp-java-html-sanitizer-20190610.3z.jar");
+       cpy_file("build/dist/owasp-java-html-sanitizer-20190610.4z.jar",             "$stage_base_dir/opt/zimbra/jetty_base/common/lib/owasp-java-html-sanitizer-20190610.4z.jar");
        cpy_file("build/dist/zmzimbratozimbramig-8.7.jar",                           "$stage_base_dir/opt/zimbra/lib/jars/zmzimbratozimbramig.jar");
        cpy_file("build/dist/jcharset-2.0.jar",                                      "$stage_base_dir/opt/zimbra/jetty_base/common/endorsed/jcharset.jar");
        cpy_file("build/dist/java-semver-0.9.0.jar",                                 "$stage_base_dir/opt/zimbra/jetty_base/common/lib/java-semver-0.9.0.jar");


### PR DESCRIPTION
Related PRs:

[java-html-sanitizer#6](https://github.com/Zimbra/java-html-sanitizer-release-20190610.1/pull/6)
[zm-mailbox#1227](https://github.com/Zimbra/zm-mailbox/pull/1227)