### PR TITLE
ZCS-11505: update library com.sun.org.apache.xml.internal to org.apache.santuario for JDK 17 support

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -147,7 +147,7 @@
     <dependency org="javax.xml.ws" name="jaxws-api" rev="2.3.1"/>
     <dependency org="com.sun.istack" name="istack-commons-runtime" rev="3.0.8"/>
     <dependency org="com.sun.xml.messaging.saaj" name="saaj-impl" rev="1.5.1"/>
-    <dependency org="com.sun.org.apache.xml.internal" name="resolver" rev="20050927"/>
+    <dependency org="org.apache.santuario" name="xmlsec" rev="3.0.0"/>
     <dependency org="javax.annotation" name="javax.annotation-api" rev="1.2"/>
     <dependency org="org.apache.xmlgraphics" name="batik-css" rev="1.7"/>
     <dependency org="org.w3c.css" name="sac" rev="1.3"/>

--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -242,6 +242,7 @@ sub stage_zimbra_store_lib($)
 
        cpy_file("build/dist/bcpkix-jdk15on-1.64.jar",                               "$stage_base_dir/opt/zimbra/jetty_base/common/lib/bcpkix-jdk15on-1.64.jar");
        cpy_file("build/dist/bcmail-jdk15on-1.64.jar",                               "$stage_base_dir/opt/zimbra/lib/ext-common/bcmail-jdk15on-1.64.jar");
+       cpy_file("build/dist/xmlsec-3.0.0.jar",                                      "$stage_base_dir/opt/zimbra/lib/ext-common/xmlsec-3.0.0.jar");
        cpy_file("build/dist/jcharset-2.0.jar",                                      "$stage_base_dir/opt/zimbra/jetty_base/common/endorsed/jcharset.jar");
        cpy_file("build/dist/zimbra-charset.jar",                                    "$stage_base_dir/opt/zimbra/jetty_base/common/endorsed/zimbra-charset.jar");
        cpy_file("build/dist/apache-log4j-extras-1.0.jar",                           "$stage_base_dir/opt/zimbra/jetty_base/common/lib/apache-log4j-extras-1.0.jar");


### PR DESCRIPTION
Issue
With JDK 17 update there  is error in validating SAML response as SamlDereferencer cannot access class com.sun.org.apache.xml.internal.security.signature.XMLSignatureInput 
```
2022-06-07 03:30:48,986 INFO  [qtp252651381-115:https://zqa-226.eng.zimbra.com/service/extension/samlreceiver] [] extensions - Error in validating SAML response.
javax.xml.crypto.dsig.XMLSignatureException: javax.xml.crypto.URIReferenceException: java.lang.IllegalAccessException: class com.zimbra.cs.security.saml.SamlDereferencer cannot access class com.sun.org.apache.xml.internal.security.signature.XMLSignatureInput (in module java.xml.crypto) because module java.xml.crypto does not export com.sun.org.apache.xml.internal.security.signature to unnamed module @2c08c9e8
        at org.jcp.xml.dsig.internal.dom.DOMReference.dereference(DOMReference.java:420) ~[java.xml.crypto:?]
        at org.jcp.xml.dsig.internal.dom.DOMReference.validate(DOMReference.java:384) ~[java.xml.crypto:?]
        at org.jcp.xml.dsig.internal.dom.DOMXMLSignature.validate(DOMXMLSignature.java:278) ~[java.xml.crypto:?]
        at com.zimbra.cs.security.saml.SamlLoginReceiverHandler.validateSignature(SamlLoginReceiverHandler.java:332) ~[?:?]
        at com.zimbra.cs.security.saml.SamlLoginReceiverHandler.validateSamlResponse(SamlLoginReceiverHandler.java:218) ~[?:?]
        at com.zimbra.cs.security.saml.SamlLoginReceiverHandler.validateSamlResponse(SamlLoginReceiverHandler.java:195) ~[?:?]
        at com.zimbra.cs.security.saml.SamlLoginReceiverHandler.handleSamlResponse(SamlLoginReceiverHandler.java:127) ~[?:?]
        at com.zimbra.cs.security.saml.SamlLoginReceiverHandler.doPost(SamlLoginReceiverHandler.java:99) ~[?:?]
```

Fix
Library com.sun.org.apache.xml.internal:20050927 is not updated to support JDK 17, switched the library to org.apache.santuario:3.0.0 which works fine.

Testing
Verified the login works with SAML  and  no exceptions are seen.

https://github.com/Zimbra/zm-saml-consumer-store/pull/12
