### PR TITLE
ZCS-11514 : Getting log4j dependency errors while upgrading from Zimbra 9 Patch24.1 to Patch25

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -10,6 +10,7 @@
     <ivy:resolve file="ivy.xml" />
     <delete dir="${build.tmp.dir}" />
     <ivy:retrieve pattern="${dist.dir}/[artifact]-[revision].[ext]" />
+    <copy file="../zm-core-utils/src/bin/zmlocalconfig" todir="${dist.dir}"/>
     <copy todir="${dist.dir}">
       <fileset dir="thirdparty" includes="*.gz" />
     </copy>

--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -232,7 +232,7 @@ sub stage_zimbra_core_lib($)
         cpy_file("build/dist/apache-jsp-9.4.46.v20220331.jar",                      "$stage_base_dir/opt/zimbra/lib/jars/apache-jsp-9.4.46.v20220331.jar");
         cpy_file("build/dist/UserAgentUtils-1.21.jar",                              "$stage_base_dir/opt/zimbra/lib/jars/UserAgentUtils-1.21.jar");
         cpy_file("build/dist/tika-core-1.24.1.jar",                                 "$stage_base_dir/opt/zimbra/lib/jars/tika-core-1.24.1.jar");
-	cpy_file("build/dist/zmlocalconfig",                                         "$stage_base_dir/opt/zimbra/lib/patches/localconfig/zmlocalconfig");
+	cpy_file("build/dist/zmlocalconfig",                                        "$stage_base_dir/opt/zimbra/lib/patches/localconfig/zmlocalconfig");
         return ["."];
 }
 

--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -232,6 +232,7 @@ sub stage_zimbra_core_lib($)
         cpy_file("build/dist/apache-jsp-9.4.46.v20220331.jar",                      "$stage_base_dir/opt/zimbra/lib/jars/apache-jsp-9.4.46.v20220331.jar");
         cpy_file("build/dist/UserAgentUtils-1.21.jar",                              "$stage_base_dir/opt/zimbra/lib/jars/UserAgentUtils-1.21.jar");
         cpy_file("build/dist/tika-core-1.24.1.jar",                                 "$stage_base_dir/opt/zimbra/lib/jars/tika-core-1.24.1.jar");
+	cpy_file("build/dist/zmlocalconfig",                                         "$stage_base_dir/opt/zimbra/lib/patches/localconfig/zmlocalconfig");
         return ["."];
 }
 
@@ -381,7 +382,9 @@ sub make_package($)
          }
       }
    }
-
+   if ( $pkg_name =~ "zimbra-common-core-libs" ){
+	   push( @cmd, "--pkg-post-install-script=scripts/postinst.sh" );
+   }
    push( @cmd, @{ [ map { "--pkg-replaces=$_"; } @{ $pkg_info->{replaces} } ] } )                                                              if ( $pkg_info->{replaces} );
    push( @cmd, @{ [ map { "--pkg-depends=$_"; } @{ $pkg_info->{other_deps} } ] } )                                                             if ( $pkg_info->{other_deps} );
    push( @cmd, @{ [ map { "--pkg-depends=$_ (>= $PKG_GRAPH{$_}->{version})"; } @{ $pkg_info->{soft_deps} } ] } )                               if ( $pkg_info->{soft_deps} );

--- a/scripts/postinst.sh
+++ b/scripts/postinst.sh
@@ -1,0 +1,4 @@
+if [ -f /opt/zimbra/bin/zmlocalconfig ]; then
+   cp -af /opt/zimbra/lib/patches/localconfig/zmlocalconfig /opt/zimbra/bin/zmlocalconfig
+   chmod 755 /opt/zimbra/bin/zmlocalconfig
+fi


### PR DESCRIPTION
**Problem:**

`zimbra-common-core-libs` package deploys log4j-2.17.1 jar's.

while we installing zimlets, post install script of zimlets trying to execute `zmmailboxdctl status` and it's giving error .


`zmmailboxdctl` `zmlocalconfig` commands trying find old log4j-1.2.16 jar's because old zmlocalconfig file has old log4j-1.2.16 jar's  PATH in that.

See https://github.com/Zimbra/zm-core-utils/blob/9.0.0.p24/src/bin/zmlocalconfig#L57

**Fix:**

We have to copy updated zmlocalconfig file after `zimbra-common-core-libs` package has been installed. So post-install script has been added to update zmlocalconfig file (which has PATH of log4j-2.17.1 jar's)


