### PR TITLE
ZCS-11826 : Added dependencies for Open IO support

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -172,6 +172,8 @@
     <dependency org="com.zaxxer" name="SparseBitSet" rev="1.2"/>
     <dependency org="com.drewnoakes" name="metadata-extractor" rev="2.16.0"/>
     <dependency org="com.adobe.xmp" name="xmpcore" rev="6.1.11"/>
+    <dependency org="io.openio.sds" name="openio-api" rev="2.0.3"/>
+    <dependency org="com.google.code.gson" name="gson" rev="2.8.2"/>
     <exclude org="com.noelios.restlet" module="com.noelios.restlet"/>
     <exclude org="javax.sql" module="jdbc-stdext"/>
     <exclude org="javax.transaction" module="jta"/>

--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -332,6 +332,11 @@ sub stage_zimbra_store_lib($)
        cpy_file("build/dist/SparseBitSet-1.2.jar",                                  "$stage_base_dir/opt/zimbra/jetty_base/common/lib/SparseBitSet-1.2.jar");
        cpy_file("build/dist/metadata-extractor-2.16.0.jar",                         "$stage_base_dir/opt/zimbra/jetty_base/common/lib/metadata-extractor-2.16.0.jar");
        cpy_file("build/dist/xmpcore-6.1.11.jar",                                    "$stage_base_dir/opt/zimbra/jetty_base/common/lib/xmpcore-6.1.11.jar");
+       cpy_file("build/dist/jackson-databind-2.10.1.jar",                           "$stage_base_dir/opt/zimbra/jetty_base/common/lib/jackson-databind-2.10.1.jar");
+       cpy_file("build/dist/jackson-core-2.10.1.jar",                               "$stage_base_dir/opt/zimbra/jetty_base/common/lib/jackson-core-2.10.1.jar");
+       cpy_file("build/dist/jackson-annotations-2.10.1.jar",                        "$stage_base_dir/opt/zimbra/jetty_base/common/lib/jackson-annotations-2.10.1.jar");
+       cpy_file("build/dist/openio-api-2.0.3.jar",                                  "$stage_base_dir/opt/zimbra/jetty_base/common/lib/openio-api-2.0.3.jar");
+       cpy_file("build/dist/gson-2.8.2.jar",                                        "$stage_base_dir/opt/zimbra/jetty_base/common/lib/gson-2.8.2.jar");
        return ["."];
 }
 


### PR DESCRIPTION
We have to included external JAR dependencies of following Jars for Open IO support, which needs to be included at path 'opt/zimbra/jetty_base/common/lib/'.

1. openio-api-2.0.3.jar
2. gson-2.8.2.jar
3. jackson-databind-2.10.1.jar
4. jackson-core-2.10.1.jar
5. jackson-annotations-2.10.1.jar

otherwise we use to get NoClassDefFoundException during server restart.