### PR TITLE
ZCS-11691 : Cannot send meeting with message attachment(.msg) using m…

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -174,6 +174,7 @@
     <dependency org="com.adobe.xmp" name="xmpcore" rev="6.1.11"/>
     <dependency org="io.openio.sds" name="openio-api" rev="2.0.3"/>
     <dependency org="com.google.code.gson" name="gson" rev="2.8.2"/>
+    <dependency org="org.apache.james" name="apache-mime4j-core" rev="0.8.7"/>
     <exclude org="com.noelios.restlet" module="com.noelios.restlet"/>
     <exclude org="javax.sql" module="jdbc-stdext"/>
     <exclude org="javax.transaction" module="jta"/>

--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -231,6 +231,7 @@ sub stage_zimbra_core_lib($)
         cpy_file("build/dist/apache-jsp-9.4.46.v20220331.jar",                      "$stage_base_dir/opt/zimbra/lib/jars/apache-jsp-9.4.46.v20220331.jar");
         cpy_file("build/dist/UserAgentUtils-1.21.jar",                              "$stage_base_dir/opt/zimbra/lib/jars/UserAgentUtils-1.21.jar");
         cpy_file("build/dist/tika-core-1.24.1.jar",                                 "$stage_base_dir/opt/zimbra/lib/jars/tika-core-1.24.1.jar");
+	cpy_file("build/dist/apache-mime4j-core-0.8.7.jar",                         "$stage_base_dir/opt/zimbra/lib/jars/apache-mime4j-core-0.8.7.jar");
 	cpy_file("build/dist/zmlocalconfig",                                        "$stage_base_dir/opt/zimbra/lib/patches/localconfig/zmlocalconfig");
         return ["."];
 }
@@ -337,6 +338,7 @@ sub stage_zimbra_store_lib($)
        cpy_file("build/dist/jackson-annotations-2.10.1.jar",                        "$stage_base_dir/opt/zimbra/jetty_base/common/lib/jackson-annotations-2.10.1.jar");
        cpy_file("build/dist/openio-api-2.0.3.jar",                                  "$stage_base_dir/opt/zimbra/jetty_base/common/lib/openio-api-2.0.3.jar");
        cpy_file("build/dist/gson-2.8.2.jar",                                        "$stage_base_dir/opt/zimbra/jetty_base/common/lib/gson-2.8.2.jar");
+       cpy_file("build/dist/apache-mime4j-core-0.8.7.jar",                          "$stage_base_dir/opt/zimbra/jetty_base/common/lib/apache-mime4j-core-0.8.7.jar");
        return ["."];
 }
 


### PR DESCRIPTION
Issue: Cannot send meeting with message attachment(.msg) using modern UI(tika-parsers issue)

Whenever we attach a .msg file while sending an invite it would fail with an error 
`ua=ZimbraXWebClient - GC103 (Windows)/9.1.0_BETA_4334;soapId=7e9080de;] SoapEngine - handler exception
java.lang.NoClassDefFoundError: org/apache/james/mime4j/codec/DecodeMonitor
at org.apache.tika.parser.microsoft.OutlookExtractor.decodeHeader(OutlookExtractor.java:563) ~[tika-parsers-1.24.1.jar:1.24.1]
at org.apache.tika.parser.microsoft.OutlookExtractor.normalizeHeaders(OutlookExtractor.java:529) ~[tika-parsers-1.24.1.jar:1.24.1]
at org.apache.tika.parser.microsoft.OutlookExtractor.parse(OutlookExtractor.java:161) ~[tika-parsers-1.24.1.jar:1.24.1]
at org.apache.tika.parser.microsoft.OfficeParser.parse(OfficeParser.java:199) ~[tika-parsers-1.24.1.jar:1.24.1]
at org.apache.tika.parser.microsoft.OfficeParser.parse(OfficeParser.java:131) ~[tika-parsers-1.24.1.jar:1.24.1]
at org.apache.tika.parser.CompositeParser.parse(CompositeParser.java:280) ~[tika-core-1.24.1.jar:1.24.1]`

Basically upon checking `DecodeMonitor` class was missing. This class is available in `org.apache.james`. Adding this resolved the issue. Raised PR in zm-mailbox as well for adding this dependency in `store/ivy.xml` PR link: https://github.com/Zimbra/zm-mailbox/pull/1362

Testing: Manual testing to send invites by adding `.msg` attachment and it's successfully sent

