### PR TITLE
ZCS-15753: remove bcmail-jdk15on.jar, saaj-impl.jar from zimbra-mbox-store-libs

### DIFF
--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -243,7 +243,6 @@ sub stage_zimbra_store_lib($)
    my $stage_base_dir = shift;
 
        cpy_file("build/dist/bcpkix-jdk15on-1.64.jar",                               "$stage_base_dir/opt/zimbra/jetty_base/common/lib/bcpkix-jdk15on-1.64.jar");
-       cpy_file("build/dist/bcmail-jdk15on-1.64.jar",                               "$stage_base_dir/opt/zimbra/lib/ext-common/bcmail-jdk15on-1.64.jar");
        cpy_file("build/dist/xmlsec-3.0.0.jar",                                      "$stage_base_dir/opt/zimbra/lib/ext-common/xmlsec-3.0.0.jar");
        cpy_file("build/dist/jakarta.json-api-2.1.3.jar",                            "$stage_base_dir/opt/zimbra/lib/ext-common/jakarta.json-api-2.1.3.jar");
        cpy_file("build/dist/jakarta.json-1.1.5.jar",                                "$stage_base_dir/opt/zimbra/lib/ext-common/jakarta.json-1.1.5.jar");
@@ -323,7 +322,6 @@ sub stage_zimbra_store_lib($)
        cpy_file("build/dist/commons-math3-3.6.1.jar",                               "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-math3-3.6.1.jar");
        cpy_file("build/dist/commons-csv-1.2.jar",                                   "$stage_base_dir/opt/zimbra/jetty_base/common/lib/commons-csv-1.2.jar");
        cpy_file("build/dist/xz-1.9.jar",                                            "$stage_base_dir/opt/zimbra/jetty_base/common/lib/xz-1.9.jar");
-       cpy_file("build/dist/saaj-impl-1.5.1.jar",                                   "$stage_base_dir/opt/zimbra/lib/ext-common/saaj-impl-1.5.1.jar");
        cpy_file("build/dist/antisamy-1.5.8z2.jar",                                   "$stage_base_dir/opt/zimbra/jetty_base/webapps/service/WEB-INF/lib/antisamy-1.5.8z2.jar");
        cpy_file("build/dist/UserAgentUtils-1.21.jar",                               "$stage_base_dir/opt/zimbra/jetty_base/common/lib/UserAgentUtils-1.21.jar");
        cpy_file("build/dist/poi-4.1.2.jar",                                         "$stage_base_dir/opt/zimbra/jetty_base/common/lib/poi-4.1.2.jar");


### PR DESCRIPTION
```
yum install zimbra-mbox-store-libs
Failed to set locale, defaulting to C
Loaded plugins: fastestmirror, langpacks
Loading mirror speeds from cached hostfile
 * base: centos.mirror.net.in
 * epel: repo.extreme-ix.org
 * extras: centos.mirror.net.in
 * updates: centos.mirror.net.in
Resolving Dependencies
--> Running transaction check
---> Package zimbra-mbox-store-libs.x86_64 0:10.0.0.1663926081-1.r7 will be updated
---> Package zimbra-mbox-store-libs.x86_64 0:10.0.7.1712031999-1.r7 will be an update
--> Finished Dependency Resolution

Dependencies Resolved

============================================================================================================================================================
 Package                                     Arch                        Version                                       Repository                      Size
============================================================================================================================================================
Updating:
 zimbra-mbox-store-libs                      x86_64                      10.0.7.1712031999-1.r7                        ZCS-14844                       63 M

Transaction Summary
============================================================================================================================================================
Upgrade  1 Package

Total size: 63 M
Is this ok [y/d/N]: y
Downloading packages:
Running transaction check
Running transaction test


Transaction check error:
  file /opt/zimbra/lib/ext-common/bcmail-jdk15on-1.64.jar from install of zimbra-mbox-store-libs-10.0.7.1712031999-1.r7.x86_64 conflicts with file from package zimbra-store-10.0.0_GA_4518.RHEL7_64-20230301065514.x86_64
  file /opt/zimbra/lib/ext-common/saaj-impl-1.5.1.jar from install of zimbra-mbox-store-libs-10.0.7.1712031999-1.r7.x86_64 conflicts with file from package zimbra-store-10.0.0_GA_4518.RHEL7_64-20230301065514.x86_64
```
The below jars are belongs to `zimbra-mbox-store-libs` and `zimbra-store` packages, removing these jars from the `zimbra-mbox-store-libs` package to fix this issue.
```
/opt/zimbra/lib/ext-common/bcmail-jdk15on-1.64.jar
/opt/zimbra/lib/ext-common/saaj-impl-1.5.1.jar
```