### PR TITLE
ZBUG-4023:Upgraded jetty to 9.4.57.v20241219

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -96,16 +96,16 @@
     <dependency org="com.fasterxml.jackson.module" name="jackson-module-jaxb-annotations" rev="2.8.9"/>
     <dependency org="org.codehaus.woodstox" name="stax2-api" rev="3.1.1"/>
     <dependency org="org.codehaus.woodstox" name="woodstox-core-asl" rev="4.2.0"/>
-    <dependency org="org.eclipse.jetty" name="jetty-continuation" rev="9.4.46.v20220331"/>
-    <dependency org="org.eclipse.jetty" name="jetty-http" rev="9.4.46.v20220331"/>
-    <dependency org="org.eclipse.jetty" name="jetty-io" rev="9.4.46.v20220331"/>
-    <dependency org="org.eclipse.jetty" name="jetty-rewrite" rev="9.4.46.v20220331"/>
-    <dependency org="org.eclipse.jetty" name="jetty-security" rev="9.4.46.v20220331"/>
-    <dependency org="org.eclipse.jetty" name="jetty-server" rev="9.4.46.v20220331"/>
-    <dependency org="org.eclipse.jetty" name="jetty-servlet" rev="9.4.46.v20220331"/>
-    <dependency org="org.eclipse.jetty" name="jetty-servlets" rev="9.4.46.v20220331"/>
-    <dependency org="org.eclipse.jetty" name="jetty-util" rev="9.4.46.v20220331"/>
-    <dependency org="org.eclipse.jetty" name="apache-jsp" rev="9.4.46.v20220331"/>
+    <dependency org="org.eclipse.jetty" name="jetty-continuation" rev="9.4.57.v20241219"/>
+    <dependency org="org.eclipse.jetty" name="jetty-http" rev="9.4.57.v20241219"/>
+    <dependency org="org.eclipse.jetty" name="jetty-io" rev="9.4.57.v20241219"/>
+    <dependency org="org.eclipse.jetty" name="jetty-rewrite" rev="9.4.57.v20241219"/>
+    <dependency org="org.eclipse.jetty" name="jetty-security" rev="9.4.57.v20241219"/>
+    <dependency org="org.eclipse.jetty" name="jetty-server" rev="9.4.57.v20241219"/>
+    <dependency org="org.eclipse.jetty" name="jetty-servlet" rev="9.4.57.v20241219"/>
+    <dependency org="org.eclipse.jetty" name="jetty-servlets" rev="9.4.57.v20241219"/>
+    <dependency org="org.eclipse.jetty" name="jetty-util" rev="9.4.57.v20241219"/>
+    <dependency org="org.eclipse.jetty" name="apache-jsp" rev="9.4.57.v20241219"/>
     <dependency org="org.ehcache" name="ehcache" rev="3.1.2"/>
     <dependency org="org.freemarker" name="freemarker" rev="2.3.19"/>
     <dependency org="org.glassfish.gmbal" name="gmbal-api-only" rev="2.2.6"/>

--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -228,7 +228,7 @@ sub stage_zimbra_core_lib($)
         cpy_file("build/dist/activation-1.1.1.jar",                                 "$stage_base_dir/opt/zimbra/lib/jars/activation-1.1.1.jar");
         cpy_file("build/dist/istack-commons-runtime-3.0.8.jar",                     "$stage_base_dir/opt/zimbra/lib/jars/istack-commons-runtime-3.0.8.jar");
         cpy_file("build/dist/javax.annotation-api-1.2.jar",                         "$stage_base_dir/opt/zimbra/lib/jars/javax.annotation-api-1.2.jar");
-        cpy_file("build/dist/apache-jsp-9.4.46.v20220331.jar",                      "$stage_base_dir/opt/zimbra/lib/jars/apache-jsp-9.4.46.v20220331.jar");
+        cpy_file("build/dist/apache-jsp-9.4.57.v20241219.jar",                      "$stage_base_dir/opt/zimbra/lib/jars/apache-jsp-9.4.57.v20241219.jar");
         cpy_file("build/dist/UserAgentUtils-1.21.jar",                              "$stage_base_dir/opt/zimbra/lib/jars/UserAgentUtils-1.21.jar");
         cpy_file("build/dist/tika-core-1.24.1.jar",                                 "$stage_base_dir/opt/zimbra/lib/jars/tika-core-1.24.1.jar");
         cpy_file("build/dist/failureaccess-1.0.1.jar",                              "$stage_base_dir/opt/zimbra/lib/jars/failureaccess-1.0.1.jar");


### PR DESCRIPTION
zimbra-jetty-distribution Upgraded to version 9.4.57.v20241219

Related PR ;-
[Zimbra/zm-build/pull/301]
[Zimbra/zm-mailbox/pull/1707]
[Zimbra/zm-jetty-conf/pull/27]
[Zimbra/zm-admin-console/pull/183]
[Zimbra/zm-web-client/pull/887]