### PR TITLE
ZCS-17472:update Java ant-1.6.5.jar for security and compatibility reasons

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -3,7 +3,7 @@
   <info organisation="zimbra" module="zm-jetty" status="integration">
  </info>
   <dependencies>
-    <dependency org="ant" name="ant" rev="1.6.5"/>
+    <dependency org="org.apache.ant" name="ant" rev="1.10.15"/>
     <dependency org="ant-contrib" name="ant-contrib" rev="1.0b2"/>
     <dependency org="org.ow2.asm" name="asm" rev="8.0.1"/>
     <dependency org="org.apache.sshd" name="sshd-common" rev="2.6.1"/>

--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -222,7 +222,7 @@ sub stage_zimbra_core_lib($)
         cpy_file("build/dist/zm-ews-stub-4.0.jar",                                  "$stage_base_dir/opt/zimbra/lib/jars/zm-ews-stub-4.0.jar");
         cpy_file("build/dist/ehcache-3.1.2.jar",                                    "$stage_base_dir/opt/zimbra/lib/jars/ehcache-3.1.2.jar");
         cpy_file("build/dist/zimbra-charset.jar",                                   "$stage_base_dir/opt/zimbra/lib/jars/zimbra-charset.jar");
-        cpy_file("build/dist/ant-1.6.5.jar",                                        "$stage_base_dir/opt/zimbra/lib/jars/ant-1.6.5.jar");
+        cpy_file("build/dist/ant-1.10.15.jar",                                      "$stage_base_dir/opt/zimbra/lib/jars/ant-1.10.15.jar");
         cpy_file("build/dist/json-20090211.jar",                                    "$stage_base_dir/opt/zimbra/lib/jars/json.jar");
         cpy_file("build/dist/commons-logging-1.1.1.jar",                            "$stage_base_dir/opt/zimbra/lib/jars/commons-logging.jar");
         cpy_file("build/dist/activation-1.1.1.jar",                                 "$stage_base_dir/opt/zimbra/lib/jars/activation-1.1.1.jar");


### PR DESCRIPTION
Code changes to update Current Ant version which is from **ant-1.6.5.jar** to **ant-1.10.15.jar**
as per official-release notes -> https://ant.apache.org/bindownload.cgi